### PR TITLE
make the testdata come from a git repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ There are unit tests in the buildHeaderLineTypeUtilities package in the file bui
 In vscode there is usually a link above the test case function name that allows you to run or debug the test case.
 For the command line this is how I do it
 
-There are also integration level tests in the structColumnDefs/definitions_test.go file. These tests use the testdata directory that is included in the repo and test most (if not all) of the various output file formats from the 12.0 version of MET. As more kinds of data are added to subsequent releases of MET this testdata directory can be modified to include sample data for new ouputfile versions. These tests are good examples of how to use the parser.
+There are also integration level tests in the structColumnDefs/definitions_test.go file. These tests use the testdata directory. That test directory has its own repo [testdata](https://github.com/NOAA-GSL/MET-parser-testdata). It has most (if not all) of the various output file formats from the 12.0 version of MET, and enough data to get a good feel for performance. As more kinds of data are added to subsequent releases of MET this testdata directory can be modified to include sample data for new ouputfile versions. These tests are good examples of how to use the parser.
 
 ```text
 ranpierce-mac1:buildHeaderLineTypeUtilities randy.pierce$ cd /Users/randy.pierce/metlinetypes/pkg/buildHeaderLineTypeUtilities/
@@ -218,7 +218,7 @@ There are more comprehensive tests in the structColumnDefs pkg.
 ```text
 Error getting line type:  UNPARSABLE_LINE: lineTypeIndex is greater than the length of the data line
 Skipping line: V12.0.0 GFS   NA   1080000   20241101_180000 20241101_180000 000000   20241101_180000 20241101_180000 RH   because it isn't parsable from file grid_stat_GFS_TMP_vs_ANLYS_TMP_Z2_1080000L_20241101_180000V.stat
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241102-00z 96
+.../testdata/G2G_v12/20241102-00z 96
 ```
 
 ```text
@@ -228,47 +228,47 @@ ranpierce-mac1:structColumnDefs randy.pierce$ go test -v ./...
 === RUN   TestParseRegressionSuite
 --- PASS: TestParseRegressionSuite (3.29s)
 === RUN   TestParseG2G_v12_Suite
-/Users/randy.pierce/metlinetypes/pkg/structColumnDefs/../../testdata/G2G_v12 672
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241031-00z 96
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241031-00z/grid_stat 1280
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241031-06z 96
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241031-06z/grid_stat 1248
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241031-12z 96
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241031-12z/grid_stat 1280
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241031-18z 96
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241031-18z/grid_stat 1248
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241101-00z 96
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241101-00z/grid_stat 1280
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241101-06z 96
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241101-06z/grid_stat 1248
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241101-12z 96
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241101-12z/grid_stat 1280
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241101-18z 96
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241101-18z/grid_stat 1248
+../../testdata/G2G_v12 672
+.../testdata/G2G_v12/20241031-00z 96
+.../testdata/G2G_v12/20241031-00z/grid_stat 1280
+.../testdata/G2G_v12/20241031-06z 96
+.../testdata/G2G_v12/20241031-06z/grid_stat 1248
+.../testdata/G2G_v12/20241031-12z 96
+.../testdata/G2G_v12/20241031-12z/grid_stat 1280
+.../testdata/G2G_v12/20241031-18z 96
+.../testdata/G2G_v12/20241031-18z/grid_stat 1248
+.../testdata/G2G_v12/20241101-00z 96
+.../testdata/G2G_v12/20241101-00z/grid_stat 1280
+.../testdata/G2G_v12/20241101-06z 96
+.../testdata/G2G_v12/20241101-06z/grid_stat 1248
+.../testdata/G2G_v12/20241101-12z 96
+.../testdata/G2G_v12/20241101-12z/grid_stat 1280
+.../testdata/G2G_v12/20241101-18z 96
+.../testdata/G2G_v12/20241101-18z/grid_stat 1248
 Error getting line type:  UNPARSABLE_LINE: lineTypeIndex is greater than the length of the data line
 Skipping line: V12.0.0 GFS   NA   1080000   20241101_180000 20241101_180000 000000   20241101_180000 20241101_180000 RH   because it isn't parsable from file grid_stat_GFS_TMP_vs_ANLYS_TMP_Z2_1080000L_20241101_180000V.stat
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241102-00z 96
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241102-00z/grid_stat 1280
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241102-06z 96
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241102-06z/grid_stat 1248
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241102-12z 96
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241102-12z/grid_stat 1280
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241102-18z 96
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241102-18z/grid_stat 1248
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241103-00z 96
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241103-00z/grid_stat 1280
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241103-06z 96
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241103-06z/grid_stat 1248
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241103-12z 96
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241103-12z/grid_stat 1280
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241103-18z 96
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241103-18z/grid_stat 1248
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241104-00z 96
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241104-00z/grid_stat 1280
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241104-06z 96
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241104-06z/grid_stat 1248
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241104-18z 96
-/Users/randy.pierce/metlinetypes/testdata/G2G_v12/20241104-18z/grid_stat 1120
+.../testdata/G2G_v12/20241102-00z 96
+.../testdata/G2G_v12/20241102-00z/grid_stat 1280
+.../testdata/G2G_v12/20241102-06z 96
+.../testdata/G2G_v12/20241102-06z/grid_stat 1248
+.../testdata/G2G_v12/20241102-12z 96
+.../testdata/G2G_v12/20241102-12z/grid_stat 1280
+.../testdata/G2G_v12/20241102-18z 96
+.../testdata/G2G_v12/20241102-18z/grid_stat 1248
+.../testdata/G2G_v12/20241103-00z 96
+.../testdata/G2G_v12/20241103-00z/grid_stat 1280
+.../testdata/G2G_v12/20241103-06z 96
+.../testdata/G2G_v12/20241103-06z/grid_stat 1248
+.../testdata/G2G_v12/20241103-12z 96
+.../testdata/G2G_v12/20241103-12z/grid_stat 1280
+.../testdata/G2G_v12/20241103-18z 96
+.../testdata/G2G_v12/20241103-18z/grid_stat 1248
+.../testdata/G2G_v12/20241104-00z 96
+.../testdata/G2G_v12/20241104-00z/grid_stat 1280
+.../testdata/G2G_v12/20241104-06z 96
+.../testdata/G2G_v12/20241104-06z/grid_stat 1248
+.../testdata/G2G_v12/20241104-18z 96
+.../testdata/G2G_v12/20241104-18z/grid_stat 1120
 --- PASS: TestParseG2G_v12_Suite (11.22s)
 PASS
 ok   parser/pkg/structColumnDefs 14.742s
@@ -286,7 +286,7 @@ To build this program use something like...
 To run this program you must provide a path to a data directory...
 
 ```text
-/tmp/regression -path=/Users/randy.pierce/metlinetypes/testdata/statfiles/
+/tmp/regression -path=.../testdata/statfiles/
 ```
 
 ## build and install

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -32,28 +32,28 @@ pks pkg/buildHeaderLineTypeUtilities, pkg/structColumnDefs and pkg/ample_parser.
 ## running the parser
 
 ```text
-bin/darwin/arm64/sample_parser -outdir /tmp -path <clone_dir>/testdata
+bin/darwin/arm64/sample_parser -outdir /tmp -path <MET-parser-tesdata>
 environment:darwin_arm64
 Recovered: runtime error: slice bounds out of range [24:10] for fileName grid_stat_GFS_TMP_vs_ANLYS_TMP_Z2_1080000L_20241101_180000V.stat
-2025/02/24 14:35:05 empty file /Users/randy.pierce/MET-parser/testdata/G2G_v12/20241101-18z/grid_stat/grid_stat_GFS_TMP_vs_ANLYS_TMP_Z2_420000L_20241101_180000V.stat - skipping
-2025/02/24 14:35:05 empty file /Users/randy.pierce/MET-parser/testdata/G2G_v12/20241101-18z/grid_stat/grid_stat_GFS_TMP_vs_ANLYS_TMP_Z2_540000L_20241101_180000V.stat - skipping
-2025/02/24 14:35:05 empty file /Users/randy.pierce/MET-parser/testdata/G2G_v12/20241101-18z/grid_stat/grid_stat_GFS_TMP_vs_ANLYS_TMP_Z2_600000L_20241101_180000V.stat - skipping
-2025/02/24 14:35:05 empty file /Users/randy.pierce/MET-parser/testdata/G2G_v12/20241101-18z/grid_stat/grid_stat_GFS_TMP_vs_ANLYS_TMP_Z2_660000L_20241101_180000V.stat - skipping
-2025/02/24 14:35:05 empty file /Users/randy.pierce/MET-parser/testdata/G2G_v12/20241101-18z/grid_stat/grid_stat_GFS_TMP_vs_ANLYS_TMP_Z2_900000L_20241101_180000V.stat - skipping
-2025/02/24 14:35:05 empty file /Users/randy.pierce/MET-parser/testdata/G2G_v12/20241102-00z/grid_stat/grid_stat_GFS_TMP_vs_ANLYS_TMP_Z2_180000L_20241102_000000V.stat - skipping
-2025/02/24 14:35:05 empty file /Users/randy.pierce/MET-parser/testdata/G2G_v12/20241102-00z/grid_stat/grid_stat_GFS_TMP_vs_ANLYS_TMP_Z2_480000L_20241102_000000V.stat - skipping
-2025/02/24 14:35:07 empty file /Users/randy.pierce/MET-parser/testdata/G2G_v12/20241103-12z/grid_stat/grid_stat_GFS_TMP_vs_ANLYS_TMP_Z2_1020000L_20241103_120000V.stat - skipping
-2025/02/24 14:35:09 missing VERSION at start of header line - bad header line? for file /Users/randy.pierce/MET-parser/testdata/__MACOSX/._G2G_v12 - skipping rest of file
-2025/02/24 14:35:11 empty file /Users/randy.pierce/MET-parser/testdata/tc_data/CMC/2023062606/tc_pairs_al92.dat.tcst - skipping
-2025/02/24 14:35:11 empty file /Users/randy.pierce/MET-parser/testdata/tc_data/CMC/2023062606/tc_pairs_al92.dat_PROBRIRW.tcst - skipping
-2025/02/24 14:35:14 empty file /Users/randy.pierce/MET-parser/testdata/tc_data/GFSO/2024081218/tc_pairs_al05.dat_PROBRIRW.tcst - skipping
-2025/02/24 14:35:17 empty file /Users/randy.pierce/MET-parser/testdata/tc_data/HMON/2023062606/tc_pairs_al03.dat.tcst - skipping
-2025/02/24 14:35:17 empty file /Users/randy.pierce/MET-parser/testdata/tc_data/HMON/2023062606/tc_pairs_al03.dat_PROBRIRW.tcst - skipping
-2025/02/24 14:35:17 empty file /Users/randy.pierce/MET-parser/testdata/tc_data/HMON/2023062606/tc_pairs_al92.dat.tcst - skipping
-2025/02/24 14:35:18 empty file /Users/randy.pierce/MET-parser/testdata/tc_data/HMON/2024081306/tc_pairs_al05.dat_PROBRIRW.tcst - skipping
-2025/02/24 14:35:18 empty file /Users/randy.pierce/MET-parser/testdata/tc_data/HWRF/2023062606/tc_pairs_al92.dat.tcst - skipping
-2025/02/24 14:35:20 missing VERSION at start of header line - bad header line? for file /Users/randy.pierce/MET-parser/testdata/tcstfiles/PROBRIRW_filter_ee.tcst - skipping rest of file
-2025/02/24 14:35:20 missing VERSION at start of header line - bad header line? for file /Users/randy.pierce/MET-parser/testdata/tcstfiles/PROBRIRW_summary_tk_err.tcst - skipping rest of file
+2025/02/24 14:35:05 empty file <MET-parser-tesdata>G2G_v12/20241101-18z/grid_stat/grid_stat_GFS_TMP_vs_ANLYS_TMP_Z2_420000L_20241101_180000V.stat - skipping
+2025/02/24 14:35:05 empty file <MET-parser-tesdata>G2G_v12/20241101-18z/grid_stat/grid_stat_GFS_TMP_vs_ANLYS_TMP_Z2_540000L_20241101_180000V.stat - skipping
+2025/02/24 14:35:05 empty file <MET-parser-tesdata>G2G_v12/20241101-18z/grid_stat/grid_stat_GFS_TMP_vs_ANLYS_TMP_Z2_600000L_20241101_180000V.stat - skipping
+2025/02/24 14:35:05 empty file <MET-parser-tesdata>G2G_v12/20241101-18z/grid_stat/grid_stat_GFS_TMP_vs_ANLYS_TMP_Z2_660000L_20241101_180000V.stat - skipping
+2025/02/24 14:35:05 empty file <MET-parser-tesdata>G2G_v12/20241101-18z/grid_stat/grid_stat_GFS_TMP_vs_ANLYS_TMP_Z2_900000L_20241101_180000V.stat - skipping
+2025/02/24 14:35:05 empty file <MET-parser-tesdata>G2G_v12/20241102-00z/grid_stat/grid_stat_GFS_TMP_vs_ANLYS_TMP_Z2_180000L_20241102_000000V.stat - skipping
+2025/02/24 14:35:05 empty file <MET-parser-tesdata>G2G_v12/20241102-00z/grid_stat/grid_stat_GFS_TMP_vs_ANLYS_TMP_Z2_480000L_20241102_000000V.stat - skipping
+2025/02/24 14:35:07 empty file <MET-parser-tesdata>G2G_v12/20241103-12z/grid_stat/grid_stat_GFS_TMP_vs_ANLYS_TMP_Z2_1020000L_20241103_120000V.stat - skipping
+2025/02/24 14:35:09 missing VERSION at start of header line - bad header line? for file <MET-parser-tesdata>__MACOSX/._G2G_v12 - skipping rest of file
+2025/02/24 14:35:11 empty file <MET-parser-tesdata>tc_data/CMC/2023062606/tc_pairs_al92.dat.tcst - skipping
+2025/02/24 14:35:11 empty file <MET-parser-tesdata>tc_data/CMC/2023062606/tc_pairs_al92.dat_PROBRIRW.tcst - skipping
+2025/02/24 14:35:14 empty file <MET-parser-tesdata>tc_data/GFSO/2024081218/tc_pairs_al05.dat_PROBRIRW.tcst - skipping
+2025/02/24 14:35:17 empty file <MET-parser-tesdata>tc_data/HMON/2023062606/tc_pairs_al03.dat.tcst - skipping
+2025/02/24 14:35:17 empty file <MET-parser-tesdata>tc_data/HMON/2023062606/tc_pairs_al03.dat_PROBRIRW.tcst - skipping
+2025/02/24 14:35:17 empty file <MET-parser-tesdata>tc_data/HMON/2023062606/tc_pairs_al92.dat.tcst - skipping
+2025/02/24 14:35:18 empty file <MET-parser-tesdata>tc_data/HMON/2024081306/tc_pairs_al05.dat_PROBRIRW.tcst - skipping
+2025/02/24 14:35:18 empty file <MET-parser-tesdata>tc_data/HWRF/2023062606/tc_pairs_al92.dat.tcst - skipping
+2025/02/24 14:35:20 missing VERSION at start of header line - bad header line? for file <MET-parser-tesdata>tcstfiles/PROBRIRW_filter_ee.tcst - skipping rest of file
+2025/02/24 14:35:20 missing VERSION at start of header line - bad header line? for file <MET-parser-tesdata>tcstfiles/PROBRIRW_summary_tk_err.tcst - skipping rest of file
 ```
 
 These messages are expected because of poorly formatted data files, empty files, or data files with missing header lines.


### PR DESCRIPTION
This is complete now. The test data is in github.com/NOAA-GSL/MET-parser-testdata. The tests automatically download the data and put it in /tmp/testdata by default but can be overridden with an environment variable "TESTDATADIR". The tests do a "git clone" if that directory does not exists or a "git pull" if it does.