### PR TITLE
handle disallowed header fields properly and did a little refactoring for version handling later

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ The metadata is used to uniquely identify each document and is used to merge doc
 
 This package also defines the DataKeyMap that is used to determine the key data fields for a given line type.
 The key data fields are used to merge documents with the same header field values excluding the key data fields.
-The key data fields can be either from the header or the data section of a record line.
+The key data fields can be either from the header or the data section of a record line. In addition there
+is a headerDisallow field that may have a list of header section fields that must be dissallowed from the header structure.
 
 ### header key data field
 
@@ -81,7 +82,7 @@ If the key data field is type header then the associated array of fields must be
 
 If the key data field is type data then the associated array of fields must all be from the data section of the record. The fields will be concatenated in the order that they are defined and separated by an "_". Those fields wont be excluded from the data section but the data section will be partitioned into a map that is indexed by the values from the OBECT_ID field.
 
-When the dataKeyFields above is applied to this document the lines with identical headers will be merged into a single document (as well as the lines with matching headers from other processed files) but because of the dataKeyMap type data definition the data records with the same OBJECT_ID will be mapped into a data map in that single document and that map will be indexed by the OBJECT_ID field.
+When the dataKeyFields above is applied to this document the lines with identical headers will be merged into a single document (as well as the lines with matching headers from other processed files) but because of the dataKeyMap type data definition the data records with the same OBJECT_ID will be mapped into a data map in that single document and that map will be indexed by the OBJECT_ID field. There is also a headerDisallow field and any header fields that are in this list will not be included in the header structure. This allows line definitions that have INIT, VALID, and LEAD times to have multiple data entries e.g. keyed by LEAD.
 
 ### other utilities
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The metadata is used to uniquely identify each document and is used to merge doc
 This package also defines the DataKeyMap that is used to determine the key data fields for a given line type.
 The key data fields are used to merge documents with the same header field values excluding the key data fields.
 The key data fields can be either from the header or the data section of a record line. In addition there
-is a headerDisallow field that may have a list of header section fields that must be dissallowed from the header structure.
+is a headerDisallow field that may have a list of header section fields that must be disallowed from the header structure.
 
 ### header key data field
 

--- a/pkg/buildHeaderLineTypes/buildHeaderLineTypes.go
+++ b/pkg/buildHeaderLineTypes/buildHeaderLineTypes.go
@@ -276,14 +276,14 @@ func getHeaderStructureString(fileType string, lineType string, getDocIDString s
 	from the met_header_columns file. A LINE_TYPE can be inferred from
 	a combination of the header fields and the data fields.
 	Also the TCMPR file type has an INIT, a VALID, and a LEAD field in the header, which means that
-	only one forecast can reside in the data section if it is indexed by the LEAD field. The asnswer
+	only one forecast can reside in the data section if it is indexed by the LEAD field. The answer
 	to this is to move the INIT field to the data section.
 	*/
 	docStructName := fmt.Sprintf("%s_%s", fileType, lineType)
 	headerStructName := fmt.Sprintf("%s_header", docStructName)
 	dataKeyMap := buildHeaderLineTypeUtilities.DataKeyMap[fileType+"_"+lineType]
 	keyFields := dataKeyMap.DataKey
-	headerDisallowed := dataKeyMap.HeaderDisallow // list of dissallowed fields
+	headerDisallowed := dataKeyMap.HeaderDisallow // list of disallowed fields
 	headerStructString := fmt.Sprintf("type %s struct {\n", headerStructName)
 	if fileType == "MODE" || fileType == "MTD" {
 		// these file types do not have a LINE_TYPE field in the header definition
@@ -321,7 +321,7 @@ func getHeaderStructureString(fileType string, lineType string, getDocIDString s
 				break
 			}
 		}
-		// skip the dataKeyFields and dissallowed fields
+		// skip the dataKeyFields and disallowed fields
 		if isDataKey || slices.Contains(headerDisallowed, term) {
 			continue
 		}

--- a/pkg/buildHeaderLineTypes/buildHeaderLineTypes.go
+++ b/pkg/buildHeaderLineTypes/buildHeaderLineTypes.go
@@ -43,31 +43,44 @@ type Pattern struct {
 	structType  string
 }
 
-var patterns = make(map[string]Pattern)
-
-var metSrcFiles = []string{
-	"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_v12.0/src/libcode/vx_analysis_util/mode_line.cc",
-	"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_v12.0/src/libcode/vx_analysis_util/stat_job.cc",
-	"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_v12.0/src/libcode/vx_grid/unstructured_grid.cc",
-	"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_v12.0/src/libcode/vx_tc_util/prob_info_base.cc",
-	"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_v12.0/src/libcode/vx_tc_util/prob_rirw_info.cc",
-	"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_v12.0/src/libcode/vx_tc_util/prob_rirw_pair_info.cc",
-	"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_v12.0/src/libcode/vx_tc_util/track_pair_info.cc",
-	"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_v12.0/src/tools/core/stat_analysis/parse_stat_line.cc",
-	"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_v12.0/src/tools/tc_utils/tc_stat/tc_stat_job.cc",
+func setMetVersion(version string) {
+	setMetSrcFiles(version)
+	setMetUserDocFiles(version)
 }
 
-var metUserDocFiles = []string{
-	"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_v12.0/docs/Users_Guide/ensemble-stat.rst",
-	"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_v12.0/docs/Users_Guide/grid-stat.rst",
-	"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_v12.0/docs/Users_Guide/gsi-tools.rst",
-	"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_v12.0/docs/Users_Guide/mode-td.rst",
-	"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_v12.0/docs/Users_Guide/mode.rst",
-	"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_v12.0/docs/Users_Guide/point-stat.rst",
-	"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_v12.0/docs/Users_Guide/stat-analysis.rst",
-	"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_v12.0/docs/Users_Guide/tc-gen.rst",
-	"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_v12.0/docs/Users_Guide/tc-pairs.rst",
-	"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_v12.0/docs/Users_Guide/wavelet-stat.rst",
+var patterns = make(map[string]Pattern)
+
+var metSrcFiles []string
+
+var metUserDocFiles []string
+
+func setMetSrcFiles(version string) {
+	metSrcFiles = []string{
+		"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_" + version + "/src/libcode/vx_analysis_util/mode_line.cc",
+		"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_" + version + "/src/libcode/vx_grid/unstructured_grid.cc",
+		"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_" + version + "/src/libcode/vx_tc_util/prob_info_base.cc",
+		"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_" + version + "/src/libcode/vx_tc_util/prob_rirw_info.cc",
+		"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_" + version + "/src/libcode/vx_tc_util/prob_rirw_pair_info.cc",
+		"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_" + version + "/src/libcode/vx_tc_util/track_pair_info.cc",
+		"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_" + version + "/src/tools/core/stat_analysis/parse_stat_line.cc",
+		"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_" + version + "/src/tools/tc_utils/tc_stat/tc_stat_job.cc",
+	}
+}
+
+func setMetUserDocFiles(version string) {
+	metUserDocFiles = []string{
+		"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_" + version + "/docs/Users_Guide/ensemble-stat.rst",
+		"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_" + version + "/docs/Users_Guide/grid-stat.rst",
+		"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_" + version + "/docs/Users_Guide/gsi-tools.rst",
+		"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_" + version + "/docs/Users_Guide/mode-td.rst",
+		"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_" + version + "/docs/Users_Guide/mode.rst",
+		"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_" + version + "/docs/Users_Guide/point-stat.rst",
+		"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_" + version + "/docs/Users_Guide/stat-analysis.rst",
+		"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_" + version + "/docs/Users_Guide/tc-gen.rst",
+		"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_" + version + "/docs/Users_Guide/tc-pairs.rst",
+		"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_" + version + "/docs/Users_Guide/wavelet-stat.rst",
+		"https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_" + version + "/src/libcode/vx_analysis_util/stat_job.cc",
+	}
 }
 
 var metHeaderColumnsFileUrl = buildHeaderLineTypeUtilities.MetHeaderColumnsFileUrl
@@ -90,6 +103,7 @@ func main() {
 	// to get the stat field types. We create a map of field names to field types. Then we have to re-iterate
 	// over the header definitions to create the structs and functions to fill the structs.
 	// read the header columns file
+	setMetVersion("v12.0")
 	met_header_columns_lines, fieldNameMap := getColumnLinesAndMapForUrl(metHeaderColumnsFileUrl)
 	metDataTypesForLines := make(map[string]string)
 	metDataTypesForLines = fillMetDataMapFromSrcFiles(metDataTypesForLines, fieldNameMap)
@@ -261,12 +275,15 @@ func getHeaderStructureString(fileType string, lineType string, getDocIDString s
 	the MODE and MTD file types do NOT HAVE a LINE_TYPE field in the header definition
 	from the met_header_columns file. A LINE_TYPE can be inferred from
 	a combination of the header fields and the data fields.
+	Also the TCMPR file type has an INIT, a VALID, and a LEAD field in the header, which means that
+	only one forecast can reside in the data section if it is indexed by the LEAD field. The asnswer
+	to this is to move the INIT field to the data section.
 	*/
-	//TODO - FIX THIS!!
 	docStructName := fmt.Sprintf("%s_%s", fileType, lineType)
 	headerStructName := fmt.Sprintf("%s_header", docStructName)
-
-	keyFields := buildHeaderLineTypeUtilities.DataKeyMap[fileType+"_"+lineType]
+	dataKeyMap := buildHeaderLineTypeUtilities.DataKeyMap[fileType+"_"+lineType]
+	keyFields := dataKeyMap.DataKey
+	headerDisallowed := dataKeyMap.HeaderDisallow // list of dissallowed fields
 	headerStructString := fmt.Sprintf("type %s struct {\n", headerStructName)
 	if fileType == "MODE" || fileType == "MTD" {
 		// these file types do not have a LINE_TYPE field in the header definition
@@ -304,8 +321,8 @@ func getHeaderStructureString(fileType string, lineType string, getDocIDString s
 				break
 			}
 		}
-		// skip the dataKeyFields
-		if isDataKey {
+		// skip the dataKeyFields and dissallowed fields
+		if isDataKey || slices.Contains(headerDisallowed, term) {
 			continue
 		}
 		// change regex type terms
@@ -345,39 +362,48 @@ func getFillStructureString(docStructName string, dataFields []string, metDataTy
 		}
 	}
 	padding2 := len("map[string]interface{}")
-	//	for index, term := range dataFields {
+	// add disallowed field terms to the dataFields and the associated data to the (embedded) fields array
+	dataFields = append(dataFields, buildHeaderLineTypeUtilities.DataKeyMap[fileType+"_"+lineType].HeaderDisallow...)
+	// iterate through the data fields to create the data struct and the fillStructure function
 	for index := 0; index < len(dataFields); index++ {
 		term := dataFields[index]
-		cleanTerm, dataType := getDataType(term, &metDataTypesForLines)
-		jsonTerm := strings.ToLower(cleanTerm)
-
-		dataStruct += fmt.Sprintf("    %-*s %-*s `json:\"%s\"`\n", padding, cleanTerm, padding2, dataType, jsonTerm)
-		var numFields int
-		var err error
-		var repeatFillStructureString string
-		fillStructureString += "\ti++; if i <= dataLen {"
-		switch dataType {
-		case "int":
-			fillStructureString += fmt.Sprintf("s.%s, _ = strconv.Atoi(fields[%d])", cleanTerm, index)
-		case "float64":
-			fillStructureString += fmt.Sprintf("s.%s, _ = strconv.ParseFloat(fields[%d], 64)", cleanTerm, index)
-		case "map[string]interface{}":
-			// this is a map which means that there are a sequence of fields that are repeated
-			numFields, repeatFillStructureString, err = getRepeatingSequenceStructureString(term, cleanTerm, fileType, lineType, index)
-			if err != nil {
-				fmt.Println("error in getRepeatingSequenceStructureString: ", err)
-			}
-			fillStructureString += repeatFillStructureString
-			index += numFields
-		default:
-			fillStructureString += fmt.Sprintf("s.%s = fields[%d]", cleanTerm, index)
-		}
-		fillStructureString += "}\n"
+		fillStructureString, dataStruct, index = getFillStructureTerm(term, metDataTypesForLines, dataStruct, padding, padding2, fillStructureString, index, fileType, lineType)
 	}
 	fillStructureString += "}\n"
 
 	dataStruct += "}\n"
 	return fillStructureString, dataStruct
+}
+
+func getFillStructureTerm(term string, metDataTypesForLines map[string]string, dataStruct string, padding int, padding2 int, fillStructureString string, index int, fileType string, lineType string) (string, string, int) {
+	_filledStructureString := fillStructureString
+	_dataStruct := dataStruct
+	cleanTerm, dataType := getDataType(term, &metDataTypesForLines)
+	jsonTerm := strings.ToLower(cleanTerm)
+
+	_dataStruct += fmt.Sprintf("    %-*s %-*s `json:\"%s\"`\n", padding, cleanTerm, padding2, dataType, jsonTerm)
+	var numFields int
+	var err error
+	var repeatFillStructureString string
+	_filledStructureString += "\ti++; if i <= dataLen {"
+	switch dataType {
+	case "int":
+		_filledStructureString += fmt.Sprintf("s.%s, _ = strconv.Atoi(fields[%d])", cleanTerm, index)
+	case "float64":
+		_filledStructureString += fmt.Sprintf("s.%s, _ = strconv.ParseFloat(fields[%d], 64)", cleanTerm, index)
+	case "map[string]interface{}":
+		// this is a map which means that there are a sequence of fields that are repeated
+		numFields, repeatFillStructureString, err = getRepeatingSequenceStructureString(term, cleanTerm, fileType, lineType, index)
+		if err != nil {
+			fmt.Println("error in getRepeatingSequenceStructureString: ", err)
+		}
+		_filledStructureString += repeatFillStructureString
+		index += numFields
+	default:
+		_filledStructureString += fmt.Sprintf("s.%s = fields[%d]", cleanTerm, index)
+	}
+	_filledStructureString += "}\n"
+	return _filledStructureString, _dataStruct, index
 }
 
 func getRepeatingSequenceStructureString(term string, cleanTerm string, fileType string, lineType string, index int) (numFields int, structureString string, err error) {

--- a/pkg/structColumnDefs/definitions.go
+++ b/pkg/structColumnDefs/definitions.go
@@ -77,6 +77,7 @@ func ParseLine(headerLine string, dataLine string, docPtr *map[string]interface{
 		// skip the .DS_Store files
 		return *docPtr, fmt.Errorf("skipping .DS_Store file")
 	}
+
 	// get the lineType
 	fileLineType, headerData, dataData, dataKey, descIndex, err := buildHeaderLineTypeUtilities.GetLineType(headerLine, dataLine, fileName)
 	if err != nil {
@@ -84,6 +85,20 @@ func ParseLine(headerLine string, dataLine string, docPtr *map[string]interface{
 		fmt.Println("Error getting line type: ", err)
 		return *docPtr, err
 	}
+	// if there are any disallowed fields in this linetype then add the disallowed data to the dataData array - in order
+	disallowedFields := buildHeaderLineTypeUtilities.DataKeyMap[fileLineType].HeaderDisallow
+	if len(disallowedFields) > 0 {
+		for _, disallowedField := range disallowedFields {
+			disAllowedFieldValue, err := buildHeaderLineTypeUtilities.GetHeaderValue(strings.Fields(headerLine), strings.Fields(dataLine), disallowedField)
+			if err != nil {
+				fmt.Println("Error getting disallowed field: ", err)
+			}
+			// if an err it appends ""
+			dataData = append(dataData, disAllowedFieldValue)
+		}
+	}
+
+	// get the tmpHeaderData without the NA values
 	tmpHeaderData := getTmpHeaderSanNA(headerData, descIndex)
 	if *docPtr == nil {
 		newDoc := make(map[string]interface{})

--- a/pkg/structColumnDefs/definitions_test.go
+++ b/pkg/structColumnDefs/definitions_test.go
@@ -139,7 +139,7 @@ func TestParseVAL1L2(t *testing.T) {
 	dataLine2 := "V12.0.0 FCST  NA   120000    20120409_120000 20120409_120000 000000   20120409_113000 20120409_123000 UGRD_VGRD m/s        Z10      UGRD_VGRD NA        Z10      ADPSFC LMV     NEAREST     1           NA          NA         NA         NA    VAL1L2     393   -0.32297       0.32197       -0.79039       0.14006       1.34214     1.86519     3.95307      1.23297    1.78245    393           26.10387   54.98572  4500.31836"
 	dataLine3 := "V12.0.0 FCST  NA   180000    20120409_120000 20120409_120000 000000   20120409_113000 20120409_123000 UGRD_VGRD m/s        Z10      UGRD_VGRD NA        Z10      ADPSFC LMV     NEAREST     1           NA          NA         NA         NA    VAL1L2     393   -0.32297       0.32197       -0.79039       0.14006       1.34214     1.86519     3.95307      1.23297    1.78245    393           26.10387   54.98572  4500.31836"
 	dataLine4 := "V12.0.0 FCST  this_is_a_long_description_field   180000    20120409_120000 20120409_120000 000000   20120409_113000 20120409_123000 UGRD_VGRD m/s        Z10      UGRD_VGRD NA        Z10      ADPSFC LMV     NEAREST     1           NA          NA         NA         NA    VAL1L2     393   -0.32297       0.32197       -0.79039       0.14006       1.34214     1.86519     3.95307      1.23297    1.78245    393           26.10387   54.98572  4500.31836"
-
+	tmpDir := t.TempDir()
 	fName := "grid_stat_ECMWF_TMP_vs_ANLYS_TMP_P1000_anom_360000L_20241031_000000V.stat"
 	var doc map[string]interface{}
 	doc, err := ParseLine(headerLine, dataLine, &doc, fName, getMissingExternalDocForId)
@@ -162,13 +162,13 @@ func TestParseVAL1L2(t *testing.T) {
 	if doc == nil {
 		t.Fatalf("Expected parsed document, got nil")
 	}
-	err = WriteJsonToCompressedFile(doc, "/tmp/test_output.json.gz")
+	err = WriteJsonToCompressedFile(doc, tmpDir+"/test_output.json.gz")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 
 	// read the file back in
-	parsedDoc, err := ReadJsonFromGzipFile("/tmp/test_output.json.gz")
+	parsedDoc, err := ReadJsonFromGzipFile(tmpDir + "/test_output.json.gz")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -205,7 +205,7 @@ func TestParseMODE_OBJ(t *testing.T) {
 	headerLine := "VERSION MODEL N_VALID GRID_RES DESC FCST_LEAD FCST_VALID      FCST_ACCUM OBS_LEAD OBS_VALID       OBS_ACCUM FCST_RAD FCST_THR OBS_RAD OBS_THR FCST_VAR FCST_UNITS FCST_LEV OBS_VAR OBS_UNITS OBS_LEV OBTYPE FIELD  TOTAL FY_OY FY_ON FN_OY FN_ON BASER   FMEAN    ACC     FBIAS  PODY       PODN    POFD     FAR     CSI        GSS       HK        HSS       ODDS      LODDS   ORSS     EDS      SEDS     EDI      SEDI     BAGSS"
 	dataLine := "V12.0.0 FCST  26026   9        NA   300000    20120410_180000 060000     120000   20050807_120000 120000    2        >=5.0    2       >=5.0   APCP_06  kg/m^2     A6       OBS     None      Surface STAGE4    RAW 26026    47  1356  5898 18725 0.22843 0.053908 0.72128 0.236  0.0079058  0.93247 0.067527 0.9665  0.0064375  -0.039178 -0.059621 -0.08155  0.11004   -2.2069 -0.80173 -0.53249 -0.3039  -0.28465 -0.28988 -0.11236"
 	dataLine2 := "V12.0.0 FCST  26026   9        this_is_a_long_description   300000    20120410_180000 060000     120000   20050807_120000 120000    2        >=5.0    2       >=5.0   APCP_06  kg/m^2     A6       OBS     None      Surface STAGE4 OBJECT 26026     4  1315  6322 18385 0.24306 0.05068  0.70656 0.2085 0.00063231 0.93325 0.066751 0.99697 0.00052349 -0.043249 -0.066119 -0.090409 0.0088459 -4.7278 -0.98246 -0.67783 -0.49927 -0.46256 -0.46613 -0.13686"
-
+	tmpDir := t.TempDir()
 	// fileType := "MODE_OBJ"
 	fName := "mode_python_mixed_300000L_20120410_180000V_060000A_cts.txt"
 	var doc map[string]interface{}
@@ -218,12 +218,12 @@ func TestParseMODE_OBJ(t *testing.T) {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 	// write the doc to a file
-	err = WriteJsonToCompressedFile(doc, "/tmp/test_output.json.gz")
+	err = WriteJsonToCompressedFile(doc, tmpDir+"/test_output.json.gz")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 	// read the file back in
-	parsedDoc, err := ReadJsonFromGzipFile("/tmp/test_output.json.gz")
+	parsedDoc, err := ReadJsonFromGzipFile(tmpDir + "/test_output.json.gz")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -255,6 +255,7 @@ func TestParseMODE_OBJ(t *testing.T) {
 
 func TestModeFile(t *testing.T) {
 	var doc map[string]interface{}
+	tmpDir := t.TempDir()
 	dir, err := getTestDataDir()
 	if err != nil {
 		t.Fatal("error getting test data directory", err)
@@ -295,13 +296,13 @@ func TestModeFile(t *testing.T) {
 	if doc == nil {
 		t.Fatalf("Expected parsed document, got nil")
 	}
-	err = WriteJsonToCompressedFile(doc, "/tmp/test_output.json.gz")
+	err = WriteJsonToCompressedFile(doc, tmpDir+"/test_output.json.gz")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 
 	// read the file back in
-	parsedDoc, err := ReadJsonFromGzipFile("/tmp/test_output.json.gz")
+	parsedDoc, err := ReadJsonFromGzipFile(tmpDir + "/test_output.json.gz")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -312,6 +313,7 @@ func TestModeFile(t *testing.T) {
 
 func TestMC_PCP_File(t *testing.T) {
 	var doc map[string]interface{}
+	tmpDir := t.TempDir()
 	dir, err := getTestDataDir()
 	if err != nil {
 		t.Fatal("error getting test data directory", err)
@@ -341,13 +343,13 @@ func TestMC_PCP_File(t *testing.T) {
 	if doc == nil {
 		t.Fatalf("Expected parsed document, got nil")
 	}
-	err = WriteJsonToCompressedFile(doc, "/tmp/test_output.json.gz")
+	err = WriteJsonToCompressedFile(doc, tmpDir+"/test_output.json.gz")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 
 	// read the file back in
-	parsedDoc, err := ReadJsonFromGzipFile("/tmp/test_output.json.gz")
+	parsedDoc, err := ReadJsonFromGzipFile(tmpDir + "/test_output.json.gz")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -358,6 +360,7 @@ func TestMC_PCP_File(t *testing.T) {
 
 func TestTC_CTS_File(t *testing.T) {
 	var doc map[string]interface{}
+	tmpDir := t.TempDir()
 	dir, err := getTestDataDir()
 	if err != nil {
 		t.Fatal("error getting test data directory", err)
@@ -387,13 +390,13 @@ func TestTC_CTS_File(t *testing.T) {
 	if doc == nil {
 		t.Fatalf("Expected parsed document, got nil")
 	}
-	err = WriteJsonToCompressedFile(doc, "/tmp/test_output.json.gz")
+	err = WriteJsonToCompressedFile(doc, tmpDir+"/test_output.json.gz")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 
 	// read the file back in
-	parsedDoc, err := ReadJsonFromGzipFile("/tmp/test_output.json.gz")
+	parsedDoc, err := ReadJsonFromGzipFile(tmpDir + "/test_output.json.gz")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -404,6 +407,7 @@ func TestTC_CTS_File(t *testing.T) {
 
 func TestMC_CTS_File(t *testing.T) {
 	var doc map[string]interface{}
+	tmpDir := t.TempDir()
 	dir, err := getTestDataDir()
 	if err != nil {
 		t.Fatal("error getting test data directory", err)
@@ -433,13 +437,13 @@ func TestMC_CTS_File(t *testing.T) {
 	if doc == nil {
 		t.Fatalf("Expected parsed document, got nil")
 	}
-	err = WriteJsonToCompressedFile(doc, "/tmp/test_output.json.gz")
+	err = WriteJsonToCompressedFile(doc, tmpDir+"/test_output.json.gz")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 
 	// read the file back in
-	parsedDoc, err := ReadJsonFromGzipFile("/tmp/test_output.json.gz")
+	parsedDoc, err := ReadJsonFromGzipFile(tmpDir + "/test_output.json.gz")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -452,6 +456,7 @@ func TestMC_CTS_File(t *testing.T) {
 // testdata/tcstfiles/al022013_interp12_fill.tcst
 func Test_TCST_File(t *testing.T) {
 	var doc map[string]interface{}
+	tmpDir := t.TempDir()
 	dir, err := getTestDataDir()
 	if err != nil {
 		t.Fatal("error getting test data directory", err)
@@ -481,13 +486,13 @@ func Test_TCST_File(t *testing.T) {
 	if doc == nil {
 		t.Fatalf("Expected parsed document, got nil")
 	}
-	err = WriteJsonToCompressedFile(doc, "/tmp/test_output.json.gz")
+	err = WriteJsonToCompressedFile(doc, tmpDir+"/test_output.json.gz")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 
 	// read the file back in
-	parsedDoc, err := ReadJsonFromGzipFile("/tmp/test_output.json.gz")
+	parsedDoc, err := ReadJsonFromGzipFile(tmpDir + "/test_output.json.gz")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -500,6 +505,7 @@ func Test_TCST_File(t *testing.T) {
 // /ttc_data/CMC/2024081306/tc_pairs_ep05.dat_PROBRIRW.tcst
 func Test_TCDATA_File(t *testing.T) {
 	var doc map[string]interface{}
+	tmpDir := t.TempDir()
 	dir, err := getTestDataDir()
 	if err != nil {
 		t.Fatal("error getting test data directory", err)
@@ -529,13 +535,13 @@ func Test_TCDATA_File(t *testing.T) {
 	if doc == nil {
 		t.Fatalf("Expected parsed document, got nil")
 	}
-	err = WriteJsonToCompressedFile(doc, "/tmp/test_output.json.gz")
+	err = WriteJsonToCompressedFile(doc, tmpDir+"/test_output.json.gz")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 
 	// read the file back in
-	parsedDoc, err := ReadJsonFromGzipFile("/tmp/test_output.json.gz")
+	parsedDoc, err := ReadJsonFromGzipFile(tmpDir + "/test_output.json.gz")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -547,6 +553,7 @@ func Test_TCDATA_File(t *testing.T) {
 // tcpairs test
 func Test_TCPAIRS_File(t *testing.T) {
 	var doc map[string]interface{}
+	tmpDir := t.TempDir()
 	dir, err := getTestDataDir()
 	if err != nil {
 		t.Fatal("error getting test data directory", err)
@@ -576,13 +583,13 @@ func Test_TCPAIRS_File(t *testing.T) {
 	if doc == nil {
 		t.Fatalf("Expected parsed document, got nil")
 	}
-	err = WriteJsonToCompressedFile(doc, "/tmp/test_output.json.gz")
+	err = WriteJsonToCompressedFile(doc, tmpDir+"/test_output.json.gz")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 
 	// read the file back in
-	parsedDoc, err := ReadJsonFromGzipFile("/tmp/test_output.json.gz")
+	parsedDoc, err := ReadJsonFromGzipFile(tmpDir + "/test_output.json.gz")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -593,6 +600,7 @@ func Test_TCPAIRS_File(t *testing.T) {
 
 func TestMC_SAL1L2_File(t *testing.T) {
 	var doc map[string]interface{}
+	tmpDir := t.TempDir()
 	dir, err := getTestDataDir()
 	if err != nil {
 		t.Fatal("error getting test data directory", err)
@@ -622,13 +630,13 @@ func TestMC_SAL1L2_File(t *testing.T) {
 	if doc == nil {
 		t.Fatalf("Expected parsed document, got nil")
 	}
-	err = WriteJsonToCompressedFile(doc, "/tmp/test_output.json.gz")
+	err = WriteJsonToCompressedFile(doc, tmpDir+"/test_output.json.gz")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 
 	// read the file back in
-	parsedDoc, err := ReadJsonFromGzipFile("/tmp/test_output.json.gz")
+	parsedDoc, err := ReadJsonFromGzipFile(tmpDir + "/test_output.json.gz")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -640,11 +648,12 @@ func TestMC_SAL1L2_File(t *testing.T) {
 func TestParseRegressionSuite(t *testing.T) {
 	var doc map[string]interface{}
 	var err error
-	path, err := os.Getwd()
+	tmpDir := t.TempDir()
+	dir, err := getTestDataDir()
 	if err != nil {
-		t.Fatal("error getting working directory:", err)
+		t.Fatal("error getting test data directory:", err)
 	}
-	directory := path + "/../../testdata/statfiles/" // The statfiles directory
+	directory := dir + "/statfiles/" // The statfiles directory
 
 	files, err := os.Open(directory) // open the directory to read files in the directory
 	if err != nil {
@@ -693,13 +702,13 @@ func TestParseRegressionSuite(t *testing.T) {
 	if doc == nil {
 		t.Fatalf("Expected parsed document, got nil")
 	}
-	err = WriteJsonToCompressedFile(doc, "/tmp/test_output.json.gz")
+	err = WriteJsonToCompressedFile(doc, tmpDir+"/test_output.json.gz")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 
 	// read the file back in
-	parsedDoc, err := ReadJsonFromGzipFile("/tmp/test_output.json.gz")
+	parsedDoc, err := ReadJsonFromGzipFile(tmpDir + "/test_output.json.gz")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -711,13 +720,12 @@ func TestParseRegressionSuite(t *testing.T) {
 func TestParseG2G_v12_Suite(t *testing.T) {
 	var doc map[string]interface{}
 	var err error
-	var path string
-
-	path, err = os.Getwd()
+	tmpDir := t.TempDir()
+	dir, err := getTestDataDir()
 	if err != nil {
-		t.Fatal("error getting working directory:", err)
+		t.Fatal("error getting test data directory:", err)
 	}
-	directory := path + "/../../testdata/G2G_v12" // The G2G_v12 top level directory
+	directory := dir + "/G2G_v12" // The G2G_v12 top level directory
 
 	err = filepath.Walk(directory,
 		func(path string, fileInfo os.FileInfo, err error) error {
@@ -774,13 +782,13 @@ func TestParseG2G_v12_Suite(t *testing.T) {
 	if doc == nil {
 		t.Fatalf("Expected parsed document, got nil")
 	}
-	err = WriteJsonToCompressedFile(doc, "/tmp/test_output.json.gz")
+	err = WriteJsonToCompressedFile(doc, tmpDir+"/test_output.json.gz")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 
 	// read the file back in
-	parsedDoc, err := ReadJsonFromGzipFile("/tmp/test_output.json.gz")
+	parsedDoc, err := ReadJsonFromGzipFile(tmpDir + "/test_output.json.gz")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -792,13 +800,12 @@ func TestParseG2G_v12_Suite(t *testing.T) {
 func TestParse_tc_data_Suite(t *testing.T) {
 	var doc map[string]interface{}
 	var err error
-	var path string
-
-	path, err = os.Getwd()
+	tmpDir := t.TempDir()
+	dir, err := getTestDataDir()
 	if err != nil {
-		t.Fatal("error getting working directory:", err)
+		t.Fatal("error getting test data directory:", err)
 	}
-	directory := path + "/../../testdata/tc_data" // The tc_data top level directory
+	directory := dir + "/tc_data" // The tc_data top level directory
 
 	err = filepath.Walk(directory,
 		func(path string, fileInfo os.FileInfo, err error) error {
@@ -855,13 +862,13 @@ func TestParse_tc_data_Suite(t *testing.T) {
 	if doc == nil {
 		t.Fatalf("Expected parsed document, got nil")
 	}
-	err = WriteJsonToCompressedFile(doc, "/tmp/test_output.json.gz")
+	err = WriteJsonToCompressedFile(doc, tmpDir+"/test_output.json.gz")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 
 	// read the file back in
-	parsedDoc, err := ReadJsonFromGzipFile("/tmp/test_output.json.gz")
+	parsedDoc, err := ReadJsonFromGzipFile(tmpDir + "/test_output.json.gz")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -873,13 +880,12 @@ func TestParse_tc_data_Suite(t *testing.T) {
 func TestParse_tcst_Suite(t *testing.T) {
 	var doc map[string]interface{}
 	var err error
-	var path string
-
-	path, err = os.Getwd()
+	tmpDir := t.TempDir()
+	dir, err := getTestDataDir()
 	if err != nil {
-		t.Fatal("error getting working directory:", err)
+		t.Fatal("error getting test data directory:", err)
 	}
-	directory := path + "/../../testdata/tcstfiles" // The tc_data top level directory
+	directory := dir + "/tcstfiles" // The tc_data top level directory
 
 	err = filepath.Walk(directory,
 		func(path string, fileInfo os.FileInfo, err error) error {
@@ -940,13 +946,13 @@ func TestParse_tcst_Suite(t *testing.T) {
 	if doc == nil {
 		t.Fatalf("Expected parsed document, got nil")
 	}
-	err = WriteJsonToCompressedFile(doc, "/tmp/test_output.json.gz")
+	err = WriteJsonToCompressedFile(doc, tmpDir+"/test_output.json.gz")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 
 	// read the file back in
-	parsedDoc, err := ReadJsonFromGzipFile("/tmp/test_output.json.gz")
+	parsedDoc, err := ReadJsonFromGzipFile(tmpDir + "/test_output.json.gz")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -958,13 +964,12 @@ func TestParse_tcst_Suite(t *testing.T) {
 func TestParse_textfiles_Suite(t *testing.T) {
 	var doc map[string]interface{}
 	var err error
-	var path string
-
-	path, err = os.Getwd()
+	tmpDir := t.TempDir()
+	dir, err := getTestDataDir()
 	if err != nil {
-		t.Fatal("error getting working directory:", err)
+		t.Fatal("error getting test data directory:", err)
 	}
-	directory := path + "/../../testdata/textfiles" // The tc_data top level directory
+	directory := dir + "/textfiles" // The tc_data top level directory
 
 	err = filepath.Walk(directory,
 		func(path string, fileInfo os.FileInfo, err error) error {
@@ -1021,13 +1026,13 @@ func TestParse_textfiles_Suite(t *testing.T) {
 	if doc == nil {
 		t.Fatalf("Expected parsed document, got nil")
 	}
-	err = WriteJsonToCompressedFile(doc, "/tmp/test_output.json.gz")
+	err = WriteJsonToCompressedFile(doc, tmpDir+"/test_output.json.gz")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 
 	// read the file back in
-	parsedDoc, err := ReadJsonFromGzipFile("/tmp/test_output.json.gz")
+	parsedDoc, err := ReadJsonFromGzipFile(tmpDir + "/test_output.json.gz")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}

--- a/pkg/structColumnDefs/definitions_test.go
+++ b/pkg/structColumnDefs/definitions_test.go
@@ -496,8 +496,55 @@ func Test_TCST_File(t *testing.T) {
 	// add other test assertions here
 }
 
+// tc_data file
+// /ttc_data/CMC/2024081306/tc_pairs_ep05.dat_PROBRIRW.tcst
+func Test_TCDATA_File(t *testing.T) {
+	var doc map[string]interface{}
+	dir, err := getTestDataDir()
+	if err != nil {
+		t.Fatal("error getting test data directory", err)
+	}
+	fName := dir + "/tc_data/CMC/2024081306/tc_pairs_ep05.dat_PROBRIRW.tcst"
+	file, err := os.Open(fName) // open the file
+	if err != nil {
+		t.Fatal("error opening file", err)
+	}
+	defer file.Close()
+	rawData, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatal("error reading file", err)
+	}
+	lines := strings.Split(string(rawData), "\n")
+	headerLine := lines[0]
+	for line := range lines {
+		if line == 0 || lines[line] == "" {
+			continue
+		}
+		dataLine := lines[line]
+		doc, err = ParseLine(headerLine, dataLine, &doc, fName, getMissingExternalDocForId)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+	}
+	if doc == nil {
+		t.Fatalf("Expected parsed document, got nil")
+	}
+	err = WriteJsonToCompressedFile(doc, "/tmp/test_output.json.gz")
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	// read the file back in
+	parsedDoc, err := ReadJsonFromGzipFile("/tmp/test_output.json.gz")
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	assert.NotNil(t, parsedDoc)
+	// add other test assertions here
+}
+
 // tcpairs test
-// testdata/tc_data/CMC/2023060100/tc_pairs_al91.dat.tcst
 func Test_TCPAIRS_File(t *testing.T) {
 	var doc map[string]interface{}
 	dir, err := getTestDataDir()

--- a/pkg/structColumnTypes/structColumnTypes.go
+++ b/pkg/structColumnTypes/structColumnTypes.go
@@ -60,7 +60,7 @@ func SetValueForField(doc *map[string]interface{}, fileType string, term string,
 const DOC_NOT_FOUND = "Document not found:"
 
 // Header struct definitions
-type STAT_ORANK_header struct {
+type STAT_VAL1L2_header struct {
 	VERSION        string  `json:"version"`
 	MODEL          string  `json:"model"`
 	DESC           string  `json:"desc"`
@@ -86,7 +86,266 @@ type STAT_ORANK_header struct {
 	LINE_TYPE      string  `json:"line_type"`
 }
 
-type STAT_PHIST_header struct {
+type STAT_MPR_header struct {
+	VERSION        string  `json:"version"`
+	MODEL          string  `json:"model"`
+	DESC           string  `json:"desc"`
+	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
+	FCST_VALID_END int     `json:"fcst_valid_end"`
+	OBS_LEAD       int     `json:"obs_lead"`
+	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
+	OBS_VALID_END  int     `json:"obs_valid_end"`
+	FCST_VAR       string  `json:"fcst_var"`
+	FCST_UNITS     string  `json:"fcst_units"`
+	FCST_LEV       string  `json:"fcst_lev"`
+	OBS_VAR        string  `json:"obs_var"`
+	OBS_UNITS      string  `json:"obs_units"`
+	OBS_LEV        string  `json:"obs_lev"`
+	OBTYPE         string  `json:"obtype"`
+	VX_MASK        string  `json:"vx_mask"`
+	INTERP_MTHD    string  `json:"interp_mthd"`
+	INTERP_PNTS    int     `json:"interp_pnts"`
+	FCST_THRESH    string  `json:"fcst_thresh"`
+	OBS_THRESH     string  `json:"obs_thresh"`
+	COV_THRESH     string  `json:"cov_thresh"`
+	ALPHA          float64 `json:"alpha"`
+	LINE_TYPE      string  `json:"line_type"`
+}
+
+type STAT_GRAD_header struct {
+	VERSION        string  `json:"version"`
+	MODEL          string  `json:"model"`
+	DESC           string  `json:"desc"`
+	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
+	FCST_VALID_END int     `json:"fcst_valid_end"`
+	OBS_LEAD       int     `json:"obs_lead"`
+	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
+	OBS_VALID_END  int     `json:"obs_valid_end"`
+	FCST_VAR       string  `json:"fcst_var"`
+	FCST_UNITS     string  `json:"fcst_units"`
+	FCST_LEV       string  `json:"fcst_lev"`
+	OBS_VAR        string  `json:"obs_var"`
+	OBS_UNITS      string  `json:"obs_units"`
+	OBS_LEV        string  `json:"obs_lev"`
+	OBTYPE         string  `json:"obtype"`
+	VX_MASK        string  `json:"vx_mask"`
+	INTERP_MTHD    string  `json:"interp_mthd"`
+	INTERP_PNTS    int     `json:"interp_pnts"`
+	FCST_THRESH    string  `json:"fcst_thresh"`
+	OBS_THRESH     string  `json:"obs_thresh"`
+	COV_THRESH     string  `json:"cov_thresh"`
+	ALPHA          float64 `json:"alpha"`
+	LINE_TYPE      string  `json:"line_type"`
+}
+
+type STAT_ECLV_header struct {
+	VERSION        string  `json:"version"`
+	MODEL          string  `json:"model"`
+	DESC           string  `json:"desc"`
+	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
+	FCST_VALID_END int     `json:"fcst_valid_end"`
+	OBS_LEAD       int     `json:"obs_lead"`
+	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
+	OBS_VALID_END  int     `json:"obs_valid_end"`
+	FCST_VAR       string  `json:"fcst_var"`
+	FCST_UNITS     string  `json:"fcst_units"`
+	FCST_LEV       string  `json:"fcst_lev"`
+	OBS_VAR        string  `json:"obs_var"`
+	OBS_UNITS      string  `json:"obs_units"`
+	OBS_LEV        string  `json:"obs_lev"`
+	OBTYPE         string  `json:"obtype"`
+	VX_MASK        string  `json:"vx_mask"`
+	INTERP_MTHD    string  `json:"interp_mthd"`
+	INTERP_PNTS    int     `json:"interp_pnts"`
+	FCST_THRESH    string  `json:"fcst_thresh"`
+	OBS_THRESH     string  `json:"obs_thresh"`
+	COV_THRESH     string  `json:"cov_thresh"`
+	ALPHA          float64 `json:"alpha"`
+	LINE_TYPE      string  `json:"line_type"`
+}
+
+type STAT_RHIST_header struct {
+	VERSION        string  `json:"version"`
+	MODEL          string  `json:"model"`
+	DESC           string  `json:"desc"`
+	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
+	FCST_VALID_END int     `json:"fcst_valid_end"`
+	OBS_LEAD       int     `json:"obs_lead"`
+	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
+	OBS_VALID_END  int     `json:"obs_valid_end"`
+	FCST_VAR       string  `json:"fcst_var"`
+	FCST_UNITS     string  `json:"fcst_units"`
+	FCST_LEV       string  `json:"fcst_lev"`
+	OBS_VAR        string  `json:"obs_var"`
+	OBS_UNITS      string  `json:"obs_units"`
+	OBS_LEV        string  `json:"obs_lev"`
+	OBTYPE         string  `json:"obtype"`
+	VX_MASK        string  `json:"vx_mask"`
+	INTERP_MTHD    string  `json:"interp_mthd"`
+	INTERP_PNTS    int     `json:"interp_pnts"`
+	FCST_THRESH    string  `json:"fcst_thresh"`
+	OBS_THRESH     string  `json:"obs_thresh"`
+	COV_THRESH     string  `json:"cov_thresh"`
+	ALPHA          float64 `json:"alpha"`
+	LINE_TYPE      string  `json:"line_type"`
+}
+
+type STAT_SSIDX_header struct {
+	VERSION        string  `json:"version"`
+	MODEL          string  `json:"model"`
+	DESC           string  `json:"desc"`
+	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
+	FCST_VALID_END int     `json:"fcst_valid_end"`
+	OBS_LEAD       int     `json:"obs_lead"`
+	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
+	OBS_VALID_END  int     `json:"obs_valid_end"`
+	FCST_VAR       string  `json:"fcst_var"`
+	FCST_UNITS     string  `json:"fcst_units"`
+	FCST_LEV       string  `json:"fcst_lev"`
+	OBS_VAR        string  `json:"obs_var"`
+	OBS_UNITS      string  `json:"obs_units"`
+	OBS_LEV        string  `json:"obs_lev"`
+	OBTYPE         string  `json:"obtype"`
+	VX_MASK        string  `json:"vx_mask"`
+	INTERP_MTHD    string  `json:"interp_mthd"`
+	INTERP_PNTS    int     `json:"interp_pnts"`
+	FCST_THRESH    string  `json:"fcst_thresh"`
+	OBS_THRESH     string  `json:"obs_thresh"`
+	COV_THRESH     string  `json:"cov_thresh"`
+	ALPHA          float64 `json:"alpha"`
+	LINE_TYPE      string  `json:"line_type"`
+}
+
+type MODE_CTS_header struct {
+	VERSION    string  `json:"version"`
+	MODEL      string  `json:"model"`
+	N_VALID    int     `json:"n_valid"`
+	GRID_RES   float64 `json:"grid_res"`
+	DESC       string  `json:"desc"`
+	FCST_VALID string  `json:"fcst_valid"`
+	FCST_ACCUM string  `json:"fcst_accum"`
+	OBS_LEAD   int     `json:"obs_lead"`
+	OBS_VALID  string  `json:"obs_valid"`
+	OBS_ACCUM  string  `json:"obs_accum"`
+	FCST_RAD   int     `json:"fcst_rad"`
+	FCST_THR   string  `json:"fcst_thr"`
+	OBS_RAD    int     `json:"obs_rad"`
+	OBS_THR    string  `json:"obs_thr"`
+	FCST_VAR   string  `json:"fcst_var"`
+	FCST_UNITS string  `json:"fcst_units"`
+	FCST_LEV   string  `json:"fcst_lev"`
+	OBS_VAR    string  `json:"obs_var"`
+	OBS_UNITS  string  `json:"obs_units"`
+	OBS_LEV    string  `json:"obs_lev"`
+	OBTYPE     string  `json:"obtype"`
+	LINE_TYPE  string  `json:"line_type"`
+}
+
+type MTD_3DPAIR_header struct {
+	VERSION    string `json:"version"`
+	MODEL      string `json:"model"`
+	DESC       string `json:"desc"`
+	FCST_LEAD  int    `json:"fcst_lead"`
+	FCST_VALID string `json:"fcst_valid"`
+	OBS_LEAD   int    `json:"obs_lead"`
+	OBS_VALID  string `json:"obs_valid"`
+	T_DELTA    string `json:"t_delta"`
+	FCST_T_BEG int    `json:"fcst_t_beg"`
+	FCST_T_END int    `json:"fcst_t_end"`
+	FCST_RAD   int    `json:"fcst_rad"`
+	FCST_THR   string `json:"fcst_thr"`
+	OBS_T_BEG  int    `json:"obs_t_beg"`
+	OBS_T_END  int    `json:"obs_t_end"`
+	OBS_RAD    int    `json:"obs_rad"`
+	OBS_THR    string `json:"obs_thr"`
+	FCST_VAR   string `json:"fcst_var"`
+	FCST_UNITS string `json:"fcst_units"`
+	FCST_LEV   string `json:"fcst_lev"`
+	OBS_VAR    string `json:"obs_var"`
+	OBS_UNITS  string `json:"obs_units"`
+	OBS_LEV    string `json:"obs_lev"`
+	LINE_TYPE  string `json:"line_type"`
+}
+
+type STAT_MCTC_header struct {
+	VERSION        string  `json:"version"`
+	MODEL          string  `json:"model"`
+	DESC           string  `json:"desc"`
+	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
+	FCST_VALID_END int     `json:"fcst_valid_end"`
+	OBS_LEAD       int     `json:"obs_lead"`
+	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
+	OBS_VALID_END  int     `json:"obs_valid_end"`
+	FCST_VAR       string  `json:"fcst_var"`
+	FCST_UNITS     string  `json:"fcst_units"`
+	FCST_LEV       string  `json:"fcst_lev"`
+	OBS_VAR        string  `json:"obs_var"`
+	OBS_UNITS      string  `json:"obs_units"`
+	OBS_LEV        string  `json:"obs_lev"`
+	OBTYPE         string  `json:"obtype"`
+	VX_MASK        string  `json:"vx_mask"`
+	INTERP_MTHD    string  `json:"interp_mthd"`
+	INTERP_PNTS    int     `json:"interp_pnts"`
+	FCST_THRESH    string  `json:"fcst_thresh"`
+	OBS_THRESH     string  `json:"obs_thresh"`
+	COV_THRESH     string  `json:"cov_thresh"`
+	ALPHA          float64 `json:"alpha"`
+	LINE_TYPE      string  `json:"line_type"`
+}
+
+type STAT_SEEPS_header struct {
+	VERSION        string  `json:"version"`
+	MODEL          string  `json:"model"`
+	DESC           string  `json:"desc"`
+	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
+	FCST_VALID_END int     `json:"fcst_valid_end"`
+	OBS_LEAD       int     `json:"obs_lead"`
+	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
+	OBS_VALID_END  int     `json:"obs_valid_end"`
+	FCST_VAR       string  `json:"fcst_var"`
+	FCST_UNITS     string  `json:"fcst_units"`
+	FCST_LEV       string  `json:"fcst_lev"`
+	OBS_VAR        string  `json:"obs_var"`
+	OBS_UNITS      string  `json:"obs_units"`
+	OBS_LEV        string  `json:"obs_lev"`
+	OBTYPE         string  `json:"obtype"`
+	VX_MASK        string  `json:"vx_mask"`
+	INTERP_MTHD    string  `json:"interp_mthd"`
+	INTERP_PNTS    int     `json:"interp_pnts"`
+	FCST_THRESH    string  `json:"fcst_thresh"`
+	OBS_THRESH     string  `json:"obs_thresh"`
+	COV_THRESH     string  `json:"cov_thresh"`
+	ALPHA          float64 `json:"alpha"`
+	LINE_TYPE      string  `json:"line_type"`
+}
+
+type STAT_PRC_header struct {
+	VERSION        string  `json:"version"`
+	MODEL          string  `json:"model"`
+	DESC           string  `json:"desc"`
+	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
+	FCST_VALID_END int     `json:"fcst_valid_end"`
+	OBS_LEAD       int     `json:"obs_lead"`
+	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
+	OBS_VALID_END  int     `json:"obs_valid_end"`
+	FCST_VAR       string  `json:"fcst_var"`
+	FCST_UNITS     string  `json:"fcst_units"`
+	FCST_LEV       string  `json:"fcst_lev"`
+	OBS_VAR        string  `json:"obs_var"`
+	OBS_UNITS      string  `json:"obs_units"`
+	OBS_LEV        string  `json:"obs_lev"`
+	OBTYPE         string  `json:"obtype"`
+	VX_MASK        string  `json:"vx_mask"`
+	INTERP_MTHD    string  `json:"interp_mthd"`
+	INTERP_PNTS    int     `json:"interp_pnts"`
+	FCST_THRESH    string  `json:"fcst_thresh"`
+	OBS_THRESH     string  `json:"obs_thresh"`
+	COV_THRESH     string  `json:"cov_thresh"`
+	ALPHA          float64 `json:"alpha"`
+	LINE_TYPE      string  `json:"line_type"`
+}
+
+type STAT_SAL1L2_header struct {
 	VERSION        string  `json:"version"`
 	MODEL          string  `json:"model"`
 	DESC           string  `json:"desc"`
@@ -138,7 +397,7 @@ type STAT_SL1L2_header struct {
 	LINE_TYPE      string  `json:"line_type"`
 }
 
-type STAT_ISC_header struct {
+type STAT_VCNT_header struct {
 	VERSION        string  `json:"version"`
 	MODEL          string  `json:"model"`
 	DESC           string  `json:"desc"`
@@ -162,61 +421,340 @@ type STAT_ISC_header struct {
 	COV_THRESH     string  `json:"cov_thresh"`
 	ALPHA          float64 `json:"alpha"`
 	LINE_TYPE      string  `json:"line_type"`
+}
+
+type MTD_2DSINGLE_header struct {
+	VERSION    string `json:"version"`
+	MODEL      string `json:"model"`
+	DESC       string `json:"desc"`
+	FCST_LEAD  int    `json:"fcst_lead"`
+	FCST_VALID string `json:"fcst_valid"`
+	OBS_LEAD   int    `json:"obs_lead"`
+	OBS_VALID  string `json:"obs_valid"`
+	T_DELTA    string `json:"t_delta"`
+	FCST_T_BEG int    `json:"fcst_t_beg"`
+	FCST_T_END int    `json:"fcst_t_end"`
+	FCST_RAD   int    `json:"fcst_rad"`
+	FCST_THR   string `json:"fcst_thr"`
+	OBS_T_BEG  int    `json:"obs_t_beg"`
+	OBS_T_END  int    `json:"obs_t_end"`
+	OBS_RAD    int    `json:"obs_rad"`
+	OBS_THR    string `json:"obs_thr"`
+	FCST_VAR   string `json:"fcst_var"`
+	FCST_UNITS string `json:"fcst_units"`
+	FCST_LEV   string `json:"fcst_lev"`
+	OBS_VAR    string `json:"obs_var"`
+	OBS_UNITS  string `json:"obs_units"`
+	OBS_LEV    string `json:"obs_lev"`
+	LINE_TYPE  string `json:"line_type"`
+}
+
+type TCST_TCMPR_header struct {
+	VERSION    string `json:"version"`
+	AMODEL     string `json:"amodel"`
+	BMODEL     string `json:"bmodel"`
+	DESC       string `json:"desc"`
+	STORM_ID   string `json:"storm_id"`
+	BASIN      string `json:"basin"`
+	CYCLONE    string `json:"cyclone"`
+	STORM_NAME string `json:"storm_name"`
+	VALID      int    `json:"valid"`
+	INIT_MASK  string `json:"init_mask"`
+	VALID_MASK string `json:"valid_mask"`
+	LINE_TYPE  string `json:"line_type"`
+}
+
+type STAT_CTC_header struct {
+	VERSION        string  `json:"version"`
+	MODEL          string  `json:"model"`
+	DESC           string  `json:"desc"`
+	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
+	FCST_VALID_END int     `json:"fcst_valid_end"`
+	OBS_LEAD       int     `json:"obs_lead"`
+	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
+	OBS_VALID_END  int     `json:"obs_valid_end"`
+	FCST_VAR       string  `json:"fcst_var"`
+	FCST_UNITS     string  `json:"fcst_units"`
+	FCST_LEV       string  `json:"fcst_lev"`
+	OBS_VAR        string  `json:"obs_var"`
+	OBS_UNITS      string  `json:"obs_units"`
+	OBS_LEV        string  `json:"obs_lev"`
+	OBTYPE         string  `json:"obtype"`
+	VX_MASK        string  `json:"vx_mask"`
+	INTERP_MTHD    string  `json:"interp_mthd"`
+	INTERP_PNTS    int     `json:"interp_pnts"`
+	FCST_THRESH    string  `json:"fcst_thresh"`
+	OBS_THRESH     string  `json:"obs_thresh"`
+	COV_THRESH     string  `json:"cov_thresh"`
+	ALPHA          float64 `json:"alpha"`
+	LINE_TYPE      string  `json:"line_type"`
+}
+
+type STAT_ORANK_header struct {
+	VERSION        string  `json:"version"`
+	MODEL          string  `json:"model"`
+	DESC           string  `json:"desc"`
+	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
+	FCST_VALID_END int     `json:"fcst_valid_end"`
+	OBS_LEAD       int     `json:"obs_lead"`
+	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
+	OBS_VALID_END  int     `json:"obs_valid_end"`
+	FCST_VAR       string  `json:"fcst_var"`
+	FCST_UNITS     string  `json:"fcst_units"`
+	FCST_LEV       string  `json:"fcst_lev"`
+	OBS_VAR        string  `json:"obs_var"`
+	OBS_UNITS      string  `json:"obs_units"`
+	OBS_LEV        string  `json:"obs_lev"`
+	OBTYPE         string  `json:"obtype"`
+	VX_MASK        string  `json:"vx_mask"`
+	INTERP_MTHD    string  `json:"interp_mthd"`
+	INTERP_PNTS    int     `json:"interp_pnts"`
+	FCST_THRESH    string  `json:"fcst_thresh"`
+	OBS_THRESH     string  `json:"obs_thresh"`
+	COV_THRESH     string  `json:"cov_thresh"`
+	ALPHA          float64 `json:"alpha"`
+	LINE_TYPE      string  `json:"line_type"`
+}
+
+type STAT_PJC_header struct {
+	VERSION        string  `json:"version"`
+	MODEL          string  `json:"model"`
+	DESC           string  `json:"desc"`
+	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
+	FCST_VALID_END int     `json:"fcst_valid_end"`
+	OBS_LEAD       int     `json:"obs_lead"`
+	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
+	OBS_VALID_END  int     `json:"obs_valid_end"`
+	FCST_VAR       string  `json:"fcst_var"`
+	FCST_UNITS     string  `json:"fcst_units"`
+	FCST_LEV       string  `json:"fcst_lev"`
+	OBS_VAR        string  `json:"obs_var"`
+	OBS_UNITS      string  `json:"obs_units"`
+	OBS_LEV        string  `json:"obs_lev"`
+	OBTYPE         string  `json:"obtype"`
+	VX_MASK        string  `json:"vx_mask"`
+	INTERP_MTHD    string  `json:"interp_mthd"`
+	INTERP_PNTS    int     `json:"interp_pnts"`
+	FCST_THRESH    string  `json:"fcst_thresh"`
+	OBS_THRESH     string  `json:"obs_thresh"`
+	COV_THRESH     string  `json:"cov_thresh"`
+	ALPHA          float64 `json:"alpha"`
+	LINE_TYPE      string  `json:"line_type"`
+}
+
+type STAT_PCT_header struct {
+	VERSION        string  `json:"version"`
+	MODEL          string  `json:"model"`
+	DESC           string  `json:"desc"`
+	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
+	FCST_VALID_END int     `json:"fcst_valid_end"`
+	OBS_LEAD       int     `json:"obs_lead"`
+	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
+	OBS_VALID_END  int     `json:"obs_valid_end"`
+	FCST_VAR       string  `json:"fcst_var"`
+	FCST_UNITS     string  `json:"fcst_units"`
+	FCST_LEV       string  `json:"fcst_lev"`
+	OBS_VAR        string  `json:"obs_var"`
+	OBS_UNITS      string  `json:"obs_units"`
+	OBS_LEV        string  `json:"obs_lev"`
+	OBTYPE         string  `json:"obtype"`
+	VX_MASK        string  `json:"vx_mask"`
+	INTERP_MTHD    string  `json:"interp_mthd"`
+	INTERP_PNTS    int     `json:"interp_pnts"`
+	FCST_THRESH    string  `json:"fcst_thresh"`
+	OBS_THRESH     string  `json:"obs_thresh"`
+	COV_THRESH     string  `json:"cov_thresh"`
+	ALPHA          float64 `json:"alpha"`
+	LINE_TYPE      string  `json:"line_type"`
+}
+
+type STAT_PSTD_header struct {
+	VERSION        string  `json:"version"`
+	MODEL          string  `json:"model"`
+	DESC           string  `json:"desc"`
+	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
+	FCST_VALID_END int     `json:"fcst_valid_end"`
+	OBS_LEAD       int     `json:"obs_lead"`
+	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
+	OBS_VALID_END  int     `json:"obs_valid_end"`
+	FCST_VAR       string  `json:"fcst_var"`
+	FCST_UNITS     string  `json:"fcst_units"`
+	FCST_LEV       string  `json:"fcst_lev"`
+	OBS_VAR        string  `json:"obs_var"`
+	OBS_UNITS      string  `json:"obs_units"`
+	OBS_LEV        string  `json:"obs_lev"`
+	OBTYPE         string  `json:"obtype"`
+	VX_MASK        string  `json:"vx_mask"`
+	INTERP_MTHD    string  `json:"interp_mthd"`
+	INTERP_PNTS    int     `json:"interp_pnts"`
+	FCST_THRESH    string  `json:"fcst_thresh"`
+	OBS_THRESH     string  `json:"obs_thresh"`
+	COV_THRESH     string  `json:"cov_thresh"`
+	ALPHA          float64 `json:"alpha"`
+	LINE_TYPE      string  `json:"line_type"`
+}
+
+type STAT_VL1L2_header struct {
+	VERSION        string  `json:"version"`
+	MODEL          string  `json:"model"`
+	DESC           string  `json:"desc"`
+	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
+	FCST_VALID_END int     `json:"fcst_valid_end"`
+	OBS_LEAD       int     `json:"obs_lead"`
+	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
+	OBS_VALID_END  int     `json:"obs_valid_end"`
+	FCST_VAR       string  `json:"fcst_var"`
+	FCST_UNITS     string  `json:"fcst_units"`
+	FCST_LEV       string  `json:"fcst_lev"`
+	OBS_VAR        string  `json:"obs_var"`
+	OBS_UNITS      string  `json:"obs_units"`
+	OBS_LEV        string  `json:"obs_lev"`
+	OBTYPE         string  `json:"obtype"`
+	VX_MASK        string  `json:"vx_mask"`
+	INTERP_MTHD    string  `json:"interp_mthd"`
+	INTERP_PNTS    int     `json:"interp_pnts"`
+	FCST_THRESH    string  `json:"fcst_thresh"`
+	OBS_THRESH     string  `json:"obs_thresh"`
+	COV_THRESH     string  `json:"cov_thresh"`
+	ALPHA          float64 `json:"alpha"`
+	LINE_TYPE      string  `json:"line_type"`
+}
+
+type MTD_3DSINGLE_header struct {
+	VERSION    string `json:"version"`
+	MODEL      string `json:"model"`
+	DESC       string `json:"desc"`
+	FCST_LEAD  int    `json:"fcst_lead"`
+	FCST_VALID string `json:"fcst_valid"`
+	OBS_LEAD   int    `json:"obs_lead"`
+	OBS_VALID  string `json:"obs_valid"`
+	T_DELTA    string `json:"t_delta"`
+	FCST_T_BEG int    `json:"fcst_t_beg"`
+	FCST_T_END int    `json:"fcst_t_end"`
+	FCST_RAD   int    `json:"fcst_rad"`
+	FCST_THR   string `json:"fcst_thr"`
+	OBS_T_BEG  int    `json:"obs_t_beg"`
+	OBS_T_END  int    `json:"obs_t_end"`
+	OBS_RAD    int    `json:"obs_rad"`
+	OBS_THR    string `json:"obs_thr"`
+	FCST_VAR   string `json:"fcst_var"`
+	FCST_UNITS string `json:"fcst_units"`
+	FCST_LEV   string `json:"fcst_lev"`
+	OBS_VAR    string `json:"obs_var"`
+	OBS_UNITS  string `json:"obs_units"`
+	OBS_LEV    string `json:"obs_lev"`
+	LINE_TYPE  string `json:"line_type"`
+}
+
+type TCST_TCDIAG_header struct {
+	VERSION    string `json:"version"`
+	AMODEL     string `json:"amodel"`
+	BMODEL     string `json:"bmodel"`
+	DESC       string `json:"desc"`
+	STORM_ID   string `json:"storm_id"`
+	BASIN      string `json:"basin"`
+	CYCLONE    string `json:"cyclone"`
+	STORM_NAME string `json:"storm_name"`
+	VALID      int    `json:"valid"`
+	INIT_MASK  string `json:"init_mask"`
+	VALID_MASK string `json:"valid_mask"`
+	LINE_TYPE  string `json:"line_type"`
+}
+
+type STAT_CTS_header struct {
+	VERSION        string  `json:"version"`
+	MODEL          string  `json:"model"`
+	DESC           string  `json:"desc"`
+	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
+	FCST_VALID_END int     `json:"fcst_valid_end"`
+	OBS_LEAD       int     `json:"obs_lead"`
+	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
+	OBS_VALID_END  int     `json:"obs_valid_end"`
+	FCST_VAR       string  `json:"fcst_var"`
+	FCST_UNITS     string  `json:"fcst_units"`
+	FCST_LEV       string  `json:"fcst_lev"`
+	OBS_VAR        string  `json:"obs_var"`
+	OBS_UNITS      string  `json:"obs_units"`
+	OBS_LEV        string  `json:"obs_lev"`
+	OBTYPE         string  `json:"obtype"`
+	VX_MASK        string  `json:"vx_mask"`
+	INTERP_MTHD    string  `json:"interp_mthd"`
+	INTERP_PNTS    int     `json:"interp_pnts"`
+	FCST_THRESH    string  `json:"fcst_thresh"`
+	OBS_THRESH     string  `json:"obs_thresh"`
+	COV_THRESH     string  `json:"cov_thresh"`
+	ALPHA          float64 `json:"alpha"`
+	LINE_TYPE      string  `json:"line_type"`
+}
+
+type STAT_NBRCNT_header struct {
+	VERSION        string  `json:"version"`
+	MODEL          string  `json:"model"`
+	DESC           string  `json:"desc"`
+	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
+	FCST_VALID_END int     `json:"fcst_valid_end"`
+	OBS_LEAD       int     `json:"obs_lead"`
+	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
+	OBS_VALID_END  int     `json:"obs_valid_end"`
+	FCST_VAR       string  `json:"fcst_var"`
+	FCST_UNITS     string  `json:"fcst_units"`
+	FCST_LEV       string  `json:"fcst_lev"`
+	OBS_VAR        string  `json:"obs_var"`
+	OBS_UNITS      string  `json:"obs_units"`
+	OBS_LEV        string  `json:"obs_lev"`
+	OBTYPE         string  `json:"obtype"`
+	VX_MASK        string  `json:"vx_mask"`
+	INTERP_MTHD    string  `json:"interp_mthd"`
+	INTERP_PNTS    int     `json:"interp_pnts"`
+	FCST_THRESH    string  `json:"fcst_thresh"`
+	OBS_THRESH     string  `json:"obs_thresh"`
+	COV_THRESH     string  `json:"cov_thresh"`
+	ALPHA          float64 `json:"alpha"`
+	LINE_TYPE      string  `json:"line_type"`
+}
+
+type STAT_DMAP_header struct {
+	VERSION        string  `json:"version"`
+	MODEL          string  `json:"model"`
+	DESC           string  `json:"desc"`
+	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
+	FCST_VALID_END int     `json:"fcst_valid_end"`
+	OBS_LEAD       int     `json:"obs_lead"`
+	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
+	OBS_VALID_END  int     `json:"obs_valid_end"`
+	FCST_VAR       string  `json:"fcst_var"`
+	FCST_UNITS     string  `json:"fcst_units"`
+	FCST_LEV       string  `json:"fcst_lev"`
+	OBS_VAR        string  `json:"obs_var"`
+	OBS_UNITS      string  `json:"obs_units"`
+	OBS_LEV        string  `json:"obs_lev"`
+	OBTYPE         string  `json:"obtype"`
+	VX_MASK        string  `json:"vx_mask"`
+	INTERP_MTHD    string  `json:"interp_mthd"`
+	INTERP_PNTS    int     `json:"interp_pnts"`
+	FCST_THRESH    string  `json:"fcst_thresh"`
+	OBS_THRESH     string  `json:"obs_thresh"`
+	COV_THRESH     string  `json:"cov_thresh"`
+	ALPHA          float64 `json:"alpha"`
+	LINE_TYPE      string  `json:"line_type"`
+}
+
+type TCST_PROBRIRW_header struct {
+	VERSION    string `json:"version"`
+	AMODEL     string `json:"amodel"`
+	BMODEL     string `json:"bmodel"`
+	DESC       string `json:"desc"`
+	STORM_ID   string `json:"storm_id"`
+	BASIN      string `json:"basin"`
+	CYCLONE    string `json:"cyclone"`
+	STORM_NAME string `json:"storm_name"`
+	VALID      int    `json:"valid"`
+	INIT_MASK  string `json:"init_mask"`
+	VALID_MASK string `json:"valid_mask"`
+	LINE_TYPE  string `json:"line_type"`
 }
 
 type STAT_RPS_header struct {
-	VERSION        string  `json:"version"`
-	MODEL          string  `json:"model"`
-	DESC           string  `json:"desc"`
-	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
-	FCST_VALID_END int     `json:"fcst_valid_end"`
-	OBS_LEAD       int     `json:"obs_lead"`
-	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
-	OBS_VALID_END  int     `json:"obs_valid_end"`
-	FCST_VAR       string  `json:"fcst_var"`
-	FCST_UNITS     string  `json:"fcst_units"`
-	FCST_LEV       string  `json:"fcst_lev"`
-	OBS_VAR        string  `json:"obs_var"`
-	OBS_UNITS      string  `json:"obs_units"`
-	OBS_LEV        string  `json:"obs_lev"`
-	OBTYPE         string  `json:"obtype"`
-	VX_MASK        string  `json:"vx_mask"`
-	INTERP_MTHD    string  `json:"interp_mthd"`
-	INTERP_PNTS    int     `json:"interp_pnts"`
-	FCST_THRESH    string  `json:"fcst_thresh"`
-	OBS_THRESH     string  `json:"obs_thresh"`
-	COV_THRESH     string  `json:"cov_thresh"`
-	ALPHA          float64 `json:"alpha"`
-	LINE_TYPE      string  `json:"line_type"`
-}
-
-type STAT_RELP_header struct {
-	VERSION        string  `json:"version"`
-	MODEL          string  `json:"model"`
-	DESC           string  `json:"desc"`
-	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
-	FCST_VALID_END int     `json:"fcst_valid_end"`
-	OBS_LEAD       int     `json:"obs_lead"`
-	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
-	OBS_VALID_END  int     `json:"obs_valid_end"`
-	FCST_VAR       string  `json:"fcst_var"`
-	FCST_UNITS     string  `json:"fcst_units"`
-	FCST_LEV       string  `json:"fcst_lev"`
-	OBS_VAR        string  `json:"obs_var"`
-	OBS_UNITS      string  `json:"obs_units"`
-	OBS_LEV        string  `json:"obs_lev"`
-	OBTYPE         string  `json:"obtype"`
-	VX_MASK        string  `json:"vx_mask"`
-	INTERP_MTHD    string  `json:"interp_mthd"`
-	INTERP_PNTS    int     `json:"interp_pnts"`
-	FCST_THRESH    string  `json:"fcst_thresh"`
-	OBS_THRESH     string  `json:"obs_thresh"`
-	COV_THRESH     string  `json:"cov_thresh"`
-	ALPHA          float64 `json:"alpha"`
-	LINE_TYPE      string  `json:"line_type"`
-}
-
-type STAT_SSVAR_header struct {
 	VERSION        string  `json:"version"`
 	MODEL          string  `json:"model"`
 	DESC           string  `json:"desc"`
@@ -268,59 +806,7 @@ type STAT_GENMPR_header struct {
 	LINE_TYPE      string  `json:"line_type"`
 }
 
-type STAT_CNT_header struct {
-	VERSION        string  `json:"version"`
-	MODEL          string  `json:"model"`
-	DESC           string  `json:"desc"`
-	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
-	FCST_VALID_END int     `json:"fcst_valid_end"`
-	OBS_LEAD       int     `json:"obs_lead"`
-	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
-	OBS_VALID_END  int     `json:"obs_valid_end"`
-	FCST_VAR       string  `json:"fcst_var"`
-	FCST_UNITS     string  `json:"fcst_units"`
-	FCST_LEV       string  `json:"fcst_lev"`
-	OBS_VAR        string  `json:"obs_var"`
-	OBS_UNITS      string  `json:"obs_units"`
-	OBS_LEV        string  `json:"obs_lev"`
-	OBTYPE         string  `json:"obtype"`
-	VX_MASK        string  `json:"vx_mask"`
-	INTERP_MTHD    string  `json:"interp_mthd"`
-	INTERP_PNTS    int     `json:"interp_pnts"`
-	FCST_THRESH    string  `json:"fcst_thresh"`
-	OBS_THRESH     string  `json:"obs_thresh"`
-	COV_THRESH     string  `json:"cov_thresh"`
-	ALPHA          float64 `json:"alpha"`
-	LINE_TYPE      string  `json:"line_type"`
-}
-
-type STAT_CTS_header struct {
-	VERSION        string  `json:"version"`
-	MODEL          string  `json:"model"`
-	DESC           string  `json:"desc"`
-	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
-	FCST_VALID_END int     `json:"fcst_valid_end"`
-	OBS_LEAD       int     `json:"obs_lead"`
-	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
-	OBS_VALID_END  int     `json:"obs_valid_end"`
-	FCST_VAR       string  `json:"fcst_var"`
-	FCST_UNITS     string  `json:"fcst_units"`
-	FCST_LEV       string  `json:"fcst_lev"`
-	OBS_VAR        string  `json:"obs_var"`
-	OBS_UNITS      string  `json:"obs_units"`
-	OBS_LEV        string  `json:"obs_lev"`
-	OBTYPE         string  `json:"obtype"`
-	VX_MASK        string  `json:"vx_mask"`
-	INTERP_MTHD    string  `json:"interp_mthd"`
-	INTERP_PNTS    int     `json:"interp_pnts"`
-	FCST_THRESH    string  `json:"fcst_thresh"`
-	OBS_THRESH     string  `json:"obs_thresh"`
-	COV_THRESH     string  `json:"cov_thresh"`
-	ALPHA          float64 `json:"alpha"`
-	LINE_TYPE      string  `json:"line_type"`
-}
-
-type STAT_FHO_header struct {
+type STAT_ISC_header struct {
 	VERSION        string  `json:"version"`
 	MODEL          string  `json:"model"`
 	DESC           string  `json:"desc"`
@@ -398,59 +884,7 @@ type STAT_NBRCTC_header struct {
 	LINE_TYPE      string  `json:"line_type"`
 }
 
-type STAT_GRAD_header struct {
-	VERSION        string  `json:"version"`
-	MODEL          string  `json:"model"`
-	DESC           string  `json:"desc"`
-	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
-	FCST_VALID_END int     `json:"fcst_valid_end"`
-	OBS_LEAD       int     `json:"obs_lead"`
-	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
-	OBS_VALID_END  int     `json:"obs_valid_end"`
-	FCST_VAR       string  `json:"fcst_var"`
-	FCST_UNITS     string  `json:"fcst_units"`
-	FCST_LEV       string  `json:"fcst_lev"`
-	OBS_VAR        string  `json:"obs_var"`
-	OBS_UNITS      string  `json:"obs_units"`
-	OBS_LEV        string  `json:"obs_lev"`
-	OBTYPE         string  `json:"obtype"`
-	VX_MASK        string  `json:"vx_mask"`
-	INTERP_MTHD    string  `json:"interp_mthd"`
-	INTERP_PNTS    int     `json:"interp_pnts"`
-	FCST_THRESH    string  `json:"fcst_thresh"`
-	OBS_THRESH     string  `json:"obs_thresh"`
-	COV_THRESH     string  `json:"cov_thresh"`
-	ALPHA          float64 `json:"alpha"`
-	LINE_TYPE      string  `json:"line_type"`
-}
-
-type STAT_VCNT_header struct {
-	VERSION        string  `json:"version"`
-	MODEL          string  `json:"model"`
-	DESC           string  `json:"desc"`
-	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
-	FCST_VALID_END int     `json:"fcst_valid_end"`
-	OBS_LEAD       int     `json:"obs_lead"`
-	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
-	OBS_VALID_END  int     `json:"obs_valid_end"`
-	FCST_VAR       string  `json:"fcst_var"`
-	FCST_UNITS     string  `json:"fcst_units"`
-	FCST_LEV       string  `json:"fcst_lev"`
-	OBS_VAR        string  `json:"obs_var"`
-	OBS_UNITS      string  `json:"obs_units"`
-	OBS_LEV        string  `json:"obs_lev"`
-	OBTYPE         string  `json:"obtype"`
-	VX_MASK        string  `json:"vx_mask"`
-	INTERP_MTHD    string  `json:"interp_mthd"`
-	INTERP_PNTS    int     `json:"interp_pnts"`
-	FCST_THRESH    string  `json:"fcst_thresh"`
-	OBS_THRESH     string  `json:"obs_thresh"`
-	COV_THRESH     string  `json:"cov_thresh"`
-	ALPHA          float64 `json:"alpha"`
-	LINE_TYPE      string  `json:"line_type"`
-}
-
-type MODE_CTS_header struct {
+type MODE_OBJ_header struct {
 	VERSION    string  `json:"version"`
 	MODEL      string  `json:"model"`
 	N_VALID    int     `json:"n_valid"`
@@ -475,7 +909,7 @@ type MODE_CTS_header struct {
 	LINE_TYPE  string  `json:"line_type"`
 }
 
-type STAT_MCTC_header struct {
+type STAT_FHO_header struct {
 	VERSION        string  `json:"version"`
 	MODEL          string  `json:"model"`
 	DESC           string  `json:"desc"`
@@ -501,7 +935,7 @@ type STAT_MCTC_header struct {
 	LINE_TYPE      string  `json:"line_type"`
 }
 
-type STAT_MCTS_header struct {
+type STAT_PHIST_header struct {
 	VERSION        string  `json:"version"`
 	MODEL          string  `json:"model"`
 	DESC           string  `json:"desc"`
@@ -527,127 +961,7 @@ type STAT_MCTS_header struct {
 	LINE_TYPE      string  `json:"line_type"`
 }
 
-type STAT_SAL1L2_header struct {
-	VERSION        string  `json:"version"`
-	MODEL          string  `json:"model"`
-	DESC           string  `json:"desc"`
-	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
-	FCST_VALID_END int     `json:"fcst_valid_end"`
-	OBS_LEAD       int     `json:"obs_lead"`
-	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
-	OBS_VALID_END  int     `json:"obs_valid_end"`
-	FCST_VAR       string  `json:"fcst_var"`
-	FCST_UNITS     string  `json:"fcst_units"`
-	FCST_LEV       string  `json:"fcst_lev"`
-	OBS_VAR        string  `json:"obs_var"`
-	OBS_UNITS      string  `json:"obs_units"`
-	OBS_LEV        string  `json:"obs_lev"`
-	OBTYPE         string  `json:"obtype"`
-	VX_MASK        string  `json:"vx_mask"`
-	INTERP_MTHD    string  `json:"interp_mthd"`
-	INTERP_PNTS    int     `json:"interp_pnts"`
-	FCST_THRESH    string  `json:"fcst_thresh"`
-	OBS_THRESH     string  `json:"obs_thresh"`
-	COV_THRESH     string  `json:"cov_thresh"`
-	ALPHA          float64 `json:"alpha"`
-	LINE_TYPE      string  `json:"line_type"`
-}
-
-type TCST_TCDIAG_header struct {
-	VERSION    string `json:"version"`
-	AMODEL     string `json:"amodel"`
-	BMODEL     string `json:"bmodel"`
-	DESC       string `json:"desc"`
-	STORM_ID   string `json:"storm_id"`
-	BASIN      string `json:"basin"`
-	CYCLONE    string `json:"cyclone"`
-	STORM_NAME string `json:"storm_name"`
-	INIT       int    `json:"init"`
-	VALID      int    `json:"valid"`
-	INIT_MASK  string `json:"init_mask"`
-	VALID_MASK string `json:"valid_mask"`
-	LINE_TYPE  string `json:"line_type"`
-}
-
-type STAT_CTC_header struct {
-	VERSION        string  `json:"version"`
-	MODEL          string  `json:"model"`
-	DESC           string  `json:"desc"`
-	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
-	FCST_VALID_END int     `json:"fcst_valid_end"`
-	OBS_LEAD       int     `json:"obs_lead"`
-	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
-	OBS_VALID_END  int     `json:"obs_valid_end"`
-	FCST_VAR       string  `json:"fcst_var"`
-	FCST_UNITS     string  `json:"fcst_units"`
-	FCST_LEV       string  `json:"fcst_lev"`
-	OBS_VAR        string  `json:"obs_var"`
-	OBS_UNITS      string  `json:"obs_units"`
-	OBS_LEV        string  `json:"obs_lev"`
-	OBTYPE         string  `json:"obtype"`
-	VX_MASK        string  `json:"vx_mask"`
-	INTERP_MTHD    string  `json:"interp_mthd"`
-	INTERP_PNTS    int     `json:"interp_pnts"`
-	FCST_THRESH    string  `json:"fcst_thresh"`
-	OBS_THRESH     string  `json:"obs_thresh"`
-	COV_THRESH     string  `json:"cov_thresh"`
-	ALPHA          float64 `json:"alpha"`
-	LINE_TYPE      string  `json:"line_type"`
-}
-
-type STAT_NBRCNT_header struct {
-	VERSION        string  `json:"version"`
-	MODEL          string  `json:"model"`
-	DESC           string  `json:"desc"`
-	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
-	FCST_VALID_END int     `json:"fcst_valid_end"`
-	OBS_LEAD       int     `json:"obs_lead"`
-	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
-	OBS_VALID_END  int     `json:"obs_valid_end"`
-	FCST_VAR       string  `json:"fcst_var"`
-	FCST_UNITS     string  `json:"fcst_units"`
-	FCST_LEV       string  `json:"fcst_lev"`
-	OBS_VAR        string  `json:"obs_var"`
-	OBS_UNITS      string  `json:"obs_units"`
-	OBS_LEV        string  `json:"obs_lev"`
-	OBTYPE         string  `json:"obtype"`
-	VX_MASK        string  `json:"vx_mask"`
-	INTERP_MTHD    string  `json:"interp_mthd"`
-	INTERP_PNTS    int     `json:"interp_pnts"`
-	FCST_THRESH    string  `json:"fcst_thresh"`
-	OBS_THRESH     string  `json:"obs_thresh"`
-	COV_THRESH     string  `json:"cov_thresh"`
-	ALPHA          float64 `json:"alpha"`
-	LINE_TYPE      string  `json:"line_type"`
-}
-
-type MTD_3DPAIR_header struct {
-	VERSION    string `json:"version"`
-	MODEL      string `json:"model"`
-	DESC       string `json:"desc"`
-	FCST_LEAD  int    `json:"fcst_lead"`
-	FCST_VALID string `json:"fcst_valid"`
-	OBS_LEAD   int    `json:"obs_lead"`
-	OBS_VALID  string `json:"obs_valid"`
-	T_DELTA    string `json:"t_delta"`
-	FCST_T_BEG int    `json:"fcst_t_beg"`
-	FCST_T_END int    `json:"fcst_t_end"`
-	FCST_RAD   int    `json:"fcst_rad"`
-	FCST_THR   string `json:"fcst_thr"`
-	OBS_T_BEG  int    `json:"obs_t_beg"`
-	OBS_T_END  int    `json:"obs_t_end"`
-	OBS_RAD    int    `json:"obs_rad"`
-	OBS_THR    string `json:"obs_thr"`
-	FCST_VAR   string `json:"fcst_var"`
-	FCST_UNITS string `json:"fcst_units"`
-	FCST_LEV   string `json:"fcst_lev"`
-	OBS_VAR    string `json:"obs_var"`
-	OBS_UNITS  string `json:"obs_units"`
-	OBS_LEV    string `json:"obs_lev"`
-	LINE_TYPE  string `json:"line_type"`
-}
-
-type STAT_PSTD_header struct {
+type STAT_RELP_header struct {
 	VERSION        string  `json:"version"`
 	MODEL          string  `json:"model"`
 	DESC           string  `json:"desc"`
@@ -699,7 +1013,7 @@ type STAT_ECNT_header struct {
 	LINE_TYPE      string  `json:"line_type"`
 }
 
-type STAT_SSIDX_header struct {
+type STAT_SSVAR_header struct {
 	VERSION        string  `json:"version"`
 	MODEL          string  `json:"model"`
 	DESC           string  `json:"desc"`
@@ -725,7 +1039,7 @@ type STAT_SSIDX_header struct {
 	LINE_TYPE      string  `json:"line_type"`
 }
 
-type STAT_VL1L2_header struct {
+type STAT_CNT_header struct {
 	VERSION        string  `json:"version"`
 	MODEL          string  `json:"model"`
 	DESC           string  `json:"desc"`
@@ -751,7 +1065,7 @@ type STAT_VL1L2_header struct {
 	LINE_TYPE      string  `json:"line_type"`
 }
 
-type STAT_MPR_header struct {
+type STAT_MCTS_header struct {
 	VERSION        string  `json:"version"`
 	MODEL          string  `json:"model"`
 	DESC           string  `json:"desc"`
@@ -803,429 +1117,8 @@ type STAT_NBRCTS_header struct {
 	LINE_TYPE      string  `json:"line_type"`
 }
 
-type STAT_DMAP_header struct {
-	VERSION        string  `json:"version"`
-	MODEL          string  `json:"model"`
-	DESC           string  `json:"desc"`
-	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
-	FCST_VALID_END int     `json:"fcst_valid_end"`
-	OBS_LEAD       int     `json:"obs_lead"`
-	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
-	OBS_VALID_END  int     `json:"obs_valid_end"`
-	FCST_VAR       string  `json:"fcst_var"`
-	FCST_UNITS     string  `json:"fcst_units"`
-	FCST_LEV       string  `json:"fcst_lev"`
-	OBS_VAR        string  `json:"obs_var"`
-	OBS_UNITS      string  `json:"obs_units"`
-	OBS_LEV        string  `json:"obs_lev"`
-	OBTYPE         string  `json:"obtype"`
-	VX_MASK        string  `json:"vx_mask"`
-	INTERP_MTHD    string  `json:"interp_mthd"`
-	INTERP_PNTS    int     `json:"interp_pnts"`
-	FCST_THRESH    string  `json:"fcst_thresh"`
-	OBS_THRESH     string  `json:"obs_thresh"`
-	COV_THRESH     string  `json:"cov_thresh"`
-	ALPHA          float64 `json:"alpha"`
-	LINE_TYPE      string  `json:"line_type"`
-}
-
-type STAT_PJC_header struct {
-	VERSION        string  `json:"version"`
-	MODEL          string  `json:"model"`
-	DESC           string  `json:"desc"`
-	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
-	FCST_VALID_END int     `json:"fcst_valid_end"`
-	OBS_LEAD       int     `json:"obs_lead"`
-	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
-	OBS_VALID_END  int     `json:"obs_valid_end"`
-	FCST_VAR       string  `json:"fcst_var"`
-	FCST_UNITS     string  `json:"fcst_units"`
-	FCST_LEV       string  `json:"fcst_lev"`
-	OBS_VAR        string  `json:"obs_var"`
-	OBS_UNITS      string  `json:"obs_units"`
-	OBS_LEV        string  `json:"obs_lev"`
-	OBTYPE         string  `json:"obtype"`
-	VX_MASK        string  `json:"vx_mask"`
-	INTERP_MTHD    string  `json:"interp_mthd"`
-	INTERP_PNTS    int     `json:"interp_pnts"`
-	FCST_THRESH    string  `json:"fcst_thresh"`
-	OBS_THRESH     string  `json:"obs_thresh"`
-	COV_THRESH     string  `json:"cov_thresh"`
-	ALPHA          float64 `json:"alpha"`
-	LINE_TYPE      string  `json:"line_type"`
-}
-
-type STAT_PRC_header struct {
-	VERSION        string  `json:"version"`
-	MODEL          string  `json:"model"`
-	DESC           string  `json:"desc"`
-	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
-	FCST_VALID_END int     `json:"fcst_valid_end"`
-	OBS_LEAD       int     `json:"obs_lead"`
-	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
-	OBS_VALID_END  int     `json:"obs_valid_end"`
-	FCST_VAR       string  `json:"fcst_var"`
-	FCST_UNITS     string  `json:"fcst_units"`
-	FCST_LEV       string  `json:"fcst_lev"`
-	OBS_VAR        string  `json:"obs_var"`
-	OBS_UNITS      string  `json:"obs_units"`
-	OBS_LEV        string  `json:"obs_lev"`
-	OBTYPE         string  `json:"obtype"`
-	VX_MASK        string  `json:"vx_mask"`
-	INTERP_MTHD    string  `json:"interp_mthd"`
-	INTERP_PNTS    int     `json:"interp_pnts"`
-	FCST_THRESH    string  `json:"fcst_thresh"`
-	OBS_THRESH     string  `json:"obs_thresh"`
-	COV_THRESH     string  `json:"cov_thresh"`
-	ALPHA          float64 `json:"alpha"`
-	LINE_TYPE      string  `json:"line_type"`
-}
-
-type STAT_RHIST_header struct {
-	VERSION        string  `json:"version"`
-	MODEL          string  `json:"model"`
-	DESC           string  `json:"desc"`
-	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
-	FCST_VALID_END int     `json:"fcst_valid_end"`
-	OBS_LEAD       int     `json:"obs_lead"`
-	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
-	OBS_VALID_END  int     `json:"obs_valid_end"`
-	FCST_VAR       string  `json:"fcst_var"`
-	FCST_UNITS     string  `json:"fcst_units"`
-	FCST_LEV       string  `json:"fcst_lev"`
-	OBS_VAR        string  `json:"obs_var"`
-	OBS_UNITS      string  `json:"obs_units"`
-	OBS_LEV        string  `json:"obs_lev"`
-	OBTYPE         string  `json:"obtype"`
-	VX_MASK        string  `json:"vx_mask"`
-	INTERP_MTHD    string  `json:"interp_mthd"`
-	INTERP_PNTS    int     `json:"interp_pnts"`
-	FCST_THRESH    string  `json:"fcst_thresh"`
-	OBS_THRESH     string  `json:"obs_thresh"`
-	COV_THRESH     string  `json:"cov_thresh"`
-	ALPHA          float64 `json:"alpha"`
-	LINE_TYPE      string  `json:"line_type"`
-}
-
-type STAT_VAL1L2_header struct {
-	VERSION        string  `json:"version"`
-	MODEL          string  `json:"model"`
-	DESC           string  `json:"desc"`
-	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
-	FCST_VALID_END int     `json:"fcst_valid_end"`
-	OBS_LEAD       int     `json:"obs_lead"`
-	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
-	OBS_VALID_END  int     `json:"obs_valid_end"`
-	FCST_VAR       string  `json:"fcst_var"`
-	FCST_UNITS     string  `json:"fcst_units"`
-	FCST_LEV       string  `json:"fcst_lev"`
-	OBS_VAR        string  `json:"obs_var"`
-	OBS_UNITS      string  `json:"obs_units"`
-	OBS_LEV        string  `json:"obs_lev"`
-	OBTYPE         string  `json:"obtype"`
-	VX_MASK        string  `json:"vx_mask"`
-	INTERP_MTHD    string  `json:"interp_mthd"`
-	INTERP_PNTS    int     `json:"interp_pnts"`
-	FCST_THRESH    string  `json:"fcst_thresh"`
-	OBS_THRESH     string  `json:"obs_thresh"`
-	COV_THRESH     string  `json:"cov_thresh"`
-	ALPHA          float64 `json:"alpha"`
-	LINE_TYPE      string  `json:"line_type"`
-}
-
-type MODE_OBJ_header struct {
-	VERSION    string  `json:"version"`
-	MODEL      string  `json:"model"`
-	N_VALID    int     `json:"n_valid"`
-	GRID_RES   float64 `json:"grid_res"`
-	DESC       string  `json:"desc"`
-	FCST_VALID string  `json:"fcst_valid"`
-	FCST_ACCUM string  `json:"fcst_accum"`
-	OBS_LEAD   int     `json:"obs_lead"`
-	OBS_VALID  string  `json:"obs_valid"`
-	OBS_ACCUM  string  `json:"obs_accum"`
-	FCST_RAD   int     `json:"fcst_rad"`
-	FCST_THR   string  `json:"fcst_thr"`
-	OBS_RAD    int     `json:"obs_rad"`
-	OBS_THR    string  `json:"obs_thr"`
-	FCST_VAR   string  `json:"fcst_var"`
-	FCST_UNITS string  `json:"fcst_units"`
-	FCST_LEV   string  `json:"fcst_lev"`
-	OBS_VAR    string  `json:"obs_var"`
-	OBS_UNITS  string  `json:"obs_units"`
-	OBS_LEV    string  `json:"obs_lev"`
-	OBTYPE     string  `json:"obtype"`
-	LINE_TYPE  string  `json:"line_type"`
-}
-
-type STAT_SEEPS_header struct {
-	VERSION        string  `json:"version"`
-	MODEL          string  `json:"model"`
-	DESC           string  `json:"desc"`
-	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
-	FCST_VALID_END int     `json:"fcst_valid_end"`
-	OBS_LEAD       int     `json:"obs_lead"`
-	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
-	OBS_VALID_END  int     `json:"obs_valid_end"`
-	FCST_VAR       string  `json:"fcst_var"`
-	FCST_UNITS     string  `json:"fcst_units"`
-	FCST_LEV       string  `json:"fcst_lev"`
-	OBS_VAR        string  `json:"obs_var"`
-	OBS_UNITS      string  `json:"obs_units"`
-	OBS_LEV        string  `json:"obs_lev"`
-	OBTYPE         string  `json:"obtype"`
-	VX_MASK        string  `json:"vx_mask"`
-	INTERP_MTHD    string  `json:"interp_mthd"`
-	INTERP_PNTS    int     `json:"interp_pnts"`
-	FCST_THRESH    string  `json:"fcst_thresh"`
-	OBS_THRESH     string  `json:"obs_thresh"`
-	COV_THRESH     string  `json:"cov_thresh"`
-	ALPHA          float64 `json:"alpha"`
-	LINE_TYPE      string  `json:"line_type"`
-}
-
-type STAT_PCT_header struct {
-	VERSION        string  `json:"version"`
-	MODEL          string  `json:"model"`
-	DESC           string  `json:"desc"`
-	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
-	FCST_VALID_END int     `json:"fcst_valid_end"`
-	OBS_LEAD       int     `json:"obs_lead"`
-	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
-	OBS_VALID_END  int     `json:"obs_valid_end"`
-	FCST_VAR       string  `json:"fcst_var"`
-	FCST_UNITS     string  `json:"fcst_units"`
-	FCST_LEV       string  `json:"fcst_lev"`
-	OBS_VAR        string  `json:"obs_var"`
-	OBS_UNITS      string  `json:"obs_units"`
-	OBS_LEV        string  `json:"obs_lev"`
-	OBTYPE         string  `json:"obtype"`
-	VX_MASK        string  `json:"vx_mask"`
-	INTERP_MTHD    string  `json:"interp_mthd"`
-	INTERP_PNTS    int     `json:"interp_pnts"`
-	FCST_THRESH    string  `json:"fcst_thresh"`
-	OBS_THRESH     string  `json:"obs_thresh"`
-	COV_THRESH     string  `json:"cov_thresh"`
-	ALPHA          float64 `json:"alpha"`
-	LINE_TYPE      string  `json:"line_type"`
-}
-
-type STAT_ECLV_header struct {
-	VERSION        string  `json:"version"`
-	MODEL          string  `json:"model"`
-	DESC           string  `json:"desc"`
-	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
-	FCST_VALID_END int     `json:"fcst_valid_end"`
-	OBS_LEAD       int     `json:"obs_lead"`
-	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
-	OBS_VALID_END  int     `json:"obs_valid_end"`
-	FCST_VAR       string  `json:"fcst_var"`
-	FCST_UNITS     string  `json:"fcst_units"`
-	FCST_LEV       string  `json:"fcst_lev"`
-	OBS_VAR        string  `json:"obs_var"`
-	OBS_UNITS      string  `json:"obs_units"`
-	OBS_LEV        string  `json:"obs_lev"`
-	OBTYPE         string  `json:"obtype"`
-	VX_MASK        string  `json:"vx_mask"`
-	INTERP_MTHD    string  `json:"interp_mthd"`
-	INTERP_PNTS    int     `json:"interp_pnts"`
-	FCST_THRESH    string  `json:"fcst_thresh"`
-	OBS_THRESH     string  `json:"obs_thresh"`
-	COV_THRESH     string  `json:"cov_thresh"`
-	ALPHA          float64 `json:"alpha"`
-	LINE_TYPE      string  `json:"line_type"`
-}
-
-type MTD_2DSINGLE_header struct {
-	VERSION    string `json:"version"`
-	MODEL      string `json:"model"`
-	DESC       string `json:"desc"`
-	FCST_LEAD  int    `json:"fcst_lead"`
-	FCST_VALID string `json:"fcst_valid"`
-	OBS_LEAD   int    `json:"obs_lead"`
-	OBS_VALID  string `json:"obs_valid"`
-	T_DELTA    string `json:"t_delta"`
-	FCST_T_BEG int    `json:"fcst_t_beg"`
-	FCST_T_END int    `json:"fcst_t_end"`
-	FCST_RAD   int    `json:"fcst_rad"`
-	FCST_THR   string `json:"fcst_thr"`
-	OBS_T_BEG  int    `json:"obs_t_beg"`
-	OBS_T_END  int    `json:"obs_t_end"`
-	OBS_RAD    int    `json:"obs_rad"`
-	OBS_THR    string `json:"obs_thr"`
-	FCST_VAR   string `json:"fcst_var"`
-	FCST_UNITS string `json:"fcst_units"`
-	FCST_LEV   string `json:"fcst_lev"`
-	OBS_VAR    string `json:"obs_var"`
-	OBS_UNITS  string `json:"obs_units"`
-	OBS_LEV    string `json:"obs_lev"`
-	LINE_TYPE  string `json:"line_type"`
-}
-
-type MTD_3DSINGLE_header struct {
-	VERSION    string `json:"version"`
-	MODEL      string `json:"model"`
-	DESC       string `json:"desc"`
-	FCST_LEAD  int    `json:"fcst_lead"`
-	FCST_VALID string `json:"fcst_valid"`
-	OBS_LEAD   int    `json:"obs_lead"`
-	OBS_VALID  string `json:"obs_valid"`
-	T_DELTA    string `json:"t_delta"`
-	FCST_T_BEG int    `json:"fcst_t_beg"`
-	FCST_T_END int    `json:"fcst_t_end"`
-	FCST_RAD   int    `json:"fcst_rad"`
-	FCST_THR   string `json:"fcst_thr"`
-	OBS_T_BEG  int    `json:"obs_t_beg"`
-	OBS_T_END  int    `json:"obs_t_end"`
-	OBS_RAD    int    `json:"obs_rad"`
-	OBS_THR    string `json:"obs_thr"`
-	FCST_VAR   string `json:"fcst_var"`
-	FCST_UNITS string `json:"fcst_units"`
-	FCST_LEV   string `json:"fcst_lev"`
-	OBS_VAR    string `json:"obs_var"`
-	OBS_UNITS  string `json:"obs_units"`
-	OBS_LEV    string `json:"obs_lev"`
-	LINE_TYPE  string `json:"line_type"`
-}
-
-type TCST_TCMPR_header struct {
-	VERSION    string `json:"version"`
-	AMODEL     string `json:"amodel"`
-	BMODEL     string `json:"bmodel"`
-	DESC       string `json:"desc"`
-	STORM_ID   string `json:"storm_id"`
-	BASIN      string `json:"basin"`
-	CYCLONE    string `json:"cyclone"`
-	STORM_NAME string `json:"storm_name"`
-	INIT       int    `json:"init"`
-	VALID      int    `json:"valid"`
-	INIT_MASK  string `json:"init_mask"`
-	VALID_MASK string `json:"valid_mask"`
-	LINE_TYPE  string `json:"line_type"`
-}
-
-type TCST_PROBRIRW_header struct {
-	VERSION    string `json:"version"`
-	AMODEL     string `json:"amodel"`
-	BMODEL     string `json:"bmodel"`
-	DESC       string `json:"desc"`
-	STORM_ID   string `json:"storm_id"`
-	BASIN      string `json:"basin"`
-	CYCLONE    string `json:"cyclone"`
-	STORM_NAME string `json:"storm_name"`
-	INIT       int    `json:"init"`
-	VALID      int    `json:"valid"`
-	INIT_MASK  string `json:"init_mask"`
-	VALID_MASK string `json:"valid_mask"`
-	LINE_TYPE  string `json:"line_type"`
-}
-
 // fillHeader functions
-func (s *STAT_PCT) fill_STAT_PCT_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *STAT_RELP) fill_STAT_RELP_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *STAT_NBRCNT) fill_STAT_NBRCNT_Header(fields []string, doc *map[string]interface{}) {
+func (s *STAT_PRC) fill_STAT_PRC_Header(fields []string, doc *map[string]interface{}) {
 	dataLen := len(fields)
 	i := -1
 	// fill the met fields leaving out "" and NA values
@@ -1329,7 +1222,7 @@ func (s *STAT_ECLV) fill_STAT_ECLV_Header(fields []string, doc *map[string]inter
 	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
 }
 
-func (s *STAT_SSVAR) fill_STAT_SSVAR_Header(fields []string, doc *map[string]interface{}) {
+func (s *STAT_RHIST) fill_STAT_RHIST_Header(fields []string, doc *map[string]interface{}) {
 	dataLen := len(fields)
 	i := -1
 	// fill the met fields leaving out "" and NA values
@@ -1379,454 +1272,9 @@ func (s *STAT_SSVAR) fill_STAT_SSVAR_Header(fields []string, doc *map[string]int
 	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
 	i++
 	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *STAT_VCNT) fill_STAT_VCNT_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *MODE_OBJ) fill_MODE_OBJ_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "MODE", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "MODE", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "MODE", "N_VALID", i, dataLen, fields, 2, "int")
-	i++
-	SetValueForField(doc, "MODE", "GRID_RES", i, dataLen, fields, 3, "float64")
-	i++
-	SetValueForField(doc, "MODE", "DESC", i, dataLen, fields, 4, "string")
-	i++
-	SetValueForField(doc, "MODE", "FCST_VALID", i, dataLen, fields, 6, "string")
-	i++
-	SetValueForField(doc, "MODE", "FCST_ACCUM", i, dataLen, fields, 7, "string")
-	i++
-	SetValueForField(doc, "MODE", "OBS_LEAD", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "MODE", "OBS_VALID", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "MODE", "OBS_ACCUM", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "MODE", "FCST_RAD", i, dataLen, fields, 11, "int")
-	i++
-	SetValueForField(doc, "MODE", "FCST_THR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "MODE", "OBS_RAD", i, dataLen, fields, 13, "int")
-	i++
-	SetValueForField(doc, "MODE", "OBS_THR", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "MODE", "FCST_VAR", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "MODE", "FCST_UNITS", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "MODE", "FCST_LEV", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "MODE", "OBS_VAR", i, dataLen, fields, 18, "string")
-	i++
-	SetValueForField(doc, "MODE", "OBS_UNITS", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "MODE", "OBS_LEV", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "MODE", "OBTYPE", i, dataLen, fields, 21, "string")
-	(*doc)["LINE_TYPE"] = "MODE_OBJ"
 }
 
 func (s *STAT_CTC) fill_STAT_CTC_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *STAT_CTS) fill_STAT_CTS_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *STAT_MCTC) fill_STAT_MCTC_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *STAT_SEEPS) fill_STAT_SEEPS_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *STAT_RPS) fill_STAT_RPS_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *TCST_TCMPR) fill_TCST_TCMPR_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "TCST", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "TCST", "AMODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "TCST", "BMODEL", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "TCST", "DESC", i, dataLen, fields, 3, "string")
-	i++
-	SetValueForField(doc, "TCST", "STORM_ID", i, dataLen, fields, 4, "string")
-	i++
-	SetValueForField(doc, "TCST", "BASIN", i, dataLen, fields, 5, "string")
-	i++
-	SetValueForField(doc, "TCST", "CYCLONE", i, dataLen, fields, 6, "string")
-	i++
-	SetValueForField(doc, "TCST", "STORM_NAME", i, dataLen, fields, 7, "string")
-	i++
-	SetValueForField(doc, "TCST", "INIT", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "TCST", "VALID", i, dataLen, fields, 10, "int")
-	i++
-	SetValueForField(doc, "TCST", "INIT_MASK", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "TCST", "VALID_MASK", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "TCST", "LINE_TYPE", i, dataLen, fields, 13, "string")
-}
-
-func (s *STAT_SEEPS_MPR) fill_STAT_SEEPS_MPR_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *STAT_NBRCTC) fill_STAT_NBRCTC_Header(fields []string, doc *map[string]interface{}) {
 	dataLen := len(fields)
 	i := -1
 	// fill the met fields leaving out "" and NA values
@@ -1930,6 +1378,211 @@ func (s *STAT_NBRCTS) fill_STAT_NBRCTS_Header(fields []string, doc *map[string]i
 	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
 }
 
+func (s *STAT_GRAD) fill_STAT_GRAD_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *STAT_ORANK) fill_STAT_ORANK_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *STAT_SL1L2) fill_STAT_SL1L2_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *MODE_CTS) fill_MODE_CTS_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "MODE", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "MODE", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "MODE", "N_VALID", i, dataLen, fields, 2, "int")
+	i++
+	SetValueForField(doc, "MODE", "GRID_RES", i, dataLen, fields, 3, "float64")
+	i++
+	SetValueForField(doc, "MODE", "DESC", i, dataLen, fields, 4, "string")
+	i++
+	SetValueForField(doc, "MODE", "FCST_VALID", i, dataLen, fields, 6, "string")
+	i++
+	SetValueForField(doc, "MODE", "FCST_ACCUM", i, dataLen, fields, 7, "string")
+	i++
+	SetValueForField(doc, "MODE", "OBS_LEAD", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "MODE", "OBS_VALID", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "MODE", "OBS_ACCUM", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "MODE", "FCST_RAD", i, dataLen, fields, 11, "int")
+	i++
+	SetValueForField(doc, "MODE", "FCST_THR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "MODE", "OBS_RAD", i, dataLen, fields, 13, "int")
+	i++
+	SetValueForField(doc, "MODE", "OBS_THR", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "MODE", "FCST_VAR", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "MODE", "FCST_UNITS", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "MODE", "FCST_LEV", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "MODE", "OBS_VAR", i, dataLen, fields, 18, "string")
+	i++
+	SetValueForField(doc, "MODE", "OBS_UNITS", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "MODE", "OBS_LEV", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "MODE", "OBTYPE", i, dataLen, fields, 21, "string")
+	(*doc)["LINE_TYPE"] = "MODE_CTS"
+}
+
 func (s *STAT_CNT) fill_STAT_CNT_Header(fields []string, doc *map[string]interface{}) {
 	dataLen := len(fields)
 	i := -1
@@ -1982,7 +1635,58 @@ func (s *STAT_CNT) fill_STAT_CNT_Header(fields []string, doc *map[string]interfa
 	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
 }
 
-func (s *STAT_FHO) fill_STAT_FHO_Header(fields []string, doc *map[string]interface{}) {
+func (s *MTD_2DSINGLE) fill_MTD_2DSINGLE_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "MTD", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "MTD", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "MTD", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "MTD", "FCST_LEAD", i, dataLen, fields, 3, "int")
+	i++
+	SetValueForField(doc, "MTD", "FCST_VALID", i, dataLen, fields, 4, "string")
+	i++
+	SetValueForField(doc, "MTD", "OBS_LEAD", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "MTD", "OBS_VALID", i, dataLen, fields, 6, "string")
+	i++
+	SetValueForField(doc, "MTD", "T_DELTA", i, dataLen, fields, 7, "string")
+	i++
+	SetValueForField(doc, "MTD", "FCST_T_BEG", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "MTD", "FCST_T_END", i, dataLen, fields, 9, "int")
+	i++
+	SetValueForField(doc, "MTD", "FCST_RAD", i, dataLen, fields, 10, "int")
+	i++
+	SetValueForField(doc, "MTD", "FCST_THR", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "MTD", "OBS_T_BEG", i, dataLen, fields, 12, "int")
+	i++
+	SetValueForField(doc, "MTD", "OBS_T_END", i, dataLen, fields, 13, "int")
+	i++
+	SetValueForField(doc, "MTD", "OBS_RAD", i, dataLen, fields, 14, "int")
+	i++
+	SetValueForField(doc, "MTD", "OBS_THR", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "MTD", "FCST_VAR", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "MTD", "FCST_UNITS", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "MTD", "FCST_LEV", i, dataLen, fields, 18, "string")
+	i++
+	SetValueForField(doc, "MTD", "OBS_VAR", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "MTD", "OBS_UNITS", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "MTD", "OBS_LEV", i, dataLen, fields, 21, "string")
+	(*doc)["LINE_TYPE"] = "MTD_2DSINGLE"
+}
+
+func (s *STAT_MCTC) fill_STAT_MCTC_Header(fields []string, doc *map[string]interface{}) {
 	dataLen := len(fields)
 	i := -1
 	// fill the met fields leaving out "" and NA values
@@ -2034,7 +1738,141 @@ func (s *STAT_FHO) fill_STAT_FHO_Header(fields []string, doc *map[string]interfa
 	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
 }
 
-func (s *STAT_ISC) fill_STAT_ISC_Header(fields []string, doc *map[string]interface{}) {
+func (s *STAT_SAL1L2) fill_STAT_SAL1L2_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *STAT_VCNT) fill_STAT_VCNT_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *TCST_TCDIAG) fill_TCST_TCDIAG_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "TCST", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "TCST", "AMODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "TCST", "BMODEL", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "TCST", "DESC", i, dataLen, fields, 3, "string")
+	i++
+	SetValueForField(doc, "TCST", "STORM_ID", i, dataLen, fields, 4, "string")
+	i++
+	SetValueForField(doc, "TCST", "BASIN", i, dataLen, fields, 5, "string")
+	i++
+	SetValueForField(doc, "TCST", "CYCLONE", i, dataLen, fields, 6, "string")
+	i++
+	SetValueForField(doc, "TCST", "STORM_NAME", i, dataLen, fields, 7, "string")
+	i++
+	SetValueForField(doc, "TCST", "VALID", i, dataLen, fields, 10, "int")
+	i++
+	SetValueForField(doc, "TCST", "INIT_MASK", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "TCST", "VALID_MASK", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "TCST", "LINE_TYPE", i, dataLen, fields, 13, "string")
+}
+
+func (s *STAT_CTS) fill_STAT_CTS_Header(fields []string, doc *map[string]interface{}) {
 	dataLen := len(fields)
 	i := -1
 	// fill the met fields leaving out "" and NA values
@@ -2190,7 +2028,7 @@ func (s *STAT_MPR) fill_STAT_MPR_Header(fields []string, doc *map[string]interfa
 	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
 }
 
-func (s *STAT_DMAP) fill_STAT_DMAP_Header(fields []string, doc *map[string]interface{}) {
+func (s *STAT_SEEPS) fill_STAT_SEEPS_Header(fields []string, doc *map[string]interface{}) {
 	dataLen := len(fields)
 	i := -1
 	// fill the met fields leaving out "" and NA values
@@ -2242,7 +2080,7 @@ func (s *STAT_DMAP) fill_STAT_DMAP_Header(fields []string, doc *map[string]inter
 	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
 }
 
-func (s *STAT_PRC) fill_STAT_PRC_Header(fields []string, doc *map[string]interface{}) {
+func (s *STAT_NBRCTC) fill_STAT_NBRCTC_Header(fields []string, doc *map[string]interface{}) {
 	dataLen := len(fields)
 	i := -1
 	// fill the met fields leaving out "" and NA values
@@ -2346,7 +2184,59 @@ func (s *STAT_PSTD) fill_STAT_PSTD_Header(fields []string, doc *map[string]inter
 	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
 }
 
-func (s *STAT_SL1L2) fill_STAT_SL1L2_Header(fields []string, doc *map[string]interface{}) {
+func (s *STAT_ECNT) fill_STAT_ECNT_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *STAT_SSVAR) fill_STAT_SSVAR_Header(fields []string, doc *map[string]interface{}) {
 	dataLen := len(fields)
 	i := -1
 	// fill the met fields leaving out "" and NA values
@@ -2450,7 +2340,7 @@ func (s *STAT_VAL1L2) fill_STAT_VAL1L2_Header(fields []string, doc *map[string]i
 	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
 }
 
-func (s *STAT_SSIDX) fill_STAT_SSIDX_Header(fields []string, doc *map[string]interface{}) {
+func (s *STAT_VL1L2) fill_STAT_VL1L2_Header(fields []string, doc *map[string]interface{}) {
 	dataLen := len(fields)
 	i := -1
 	// fill the met fields leaving out "" and NA values
@@ -2502,108 +2392,53 @@ func (s *STAT_SSIDX) fill_STAT_SSIDX_Header(fields []string, doc *map[string]int
 	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
 }
 
-func (s *STAT_PJC) fill_STAT_PJC_Header(fields []string, doc *map[string]interface{}) {
+func (s *MODE_OBJ) fill_MODE_OBJ_Header(fields []string, doc *map[string]interface{}) {
 	dataLen := len(fields)
 	i := -1
 	// fill the met fields leaving out "" and NA values
 	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	SetValueForField(doc, "MODE", "VERSION", i, dataLen, fields, 0, "string")
 	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	SetValueForField(doc, "MODE", "MODEL", i, dataLen, fields, 1, "string")
 	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	SetValueForField(doc, "MODE", "N_VALID", i, dataLen, fields, 2, "int")
 	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	SetValueForField(doc, "MODE", "GRID_RES", i, dataLen, fields, 3, "float64")
 	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	SetValueForField(doc, "MODE", "DESC", i, dataLen, fields, 4, "string")
 	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	SetValueForField(doc, "MODE", "FCST_VALID", i, dataLen, fields, 6, "string")
 	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	SetValueForField(doc, "MODE", "FCST_ACCUM", i, dataLen, fields, 7, "string")
 	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	SetValueForField(doc, "MODE", "OBS_LEAD", i, dataLen, fields, 8, "int")
 	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	SetValueForField(doc, "MODE", "OBS_VALID", i, dataLen, fields, 9, "string")
 	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	SetValueForField(doc, "MODE", "OBS_ACCUM", i, dataLen, fields, 10, "string")
 	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	SetValueForField(doc, "MODE", "FCST_RAD", i, dataLen, fields, 11, "int")
 	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	SetValueForField(doc, "MODE", "FCST_THR", i, dataLen, fields, 12, "string")
 	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	SetValueForField(doc, "MODE", "OBS_RAD", i, dataLen, fields, 13, "int")
 	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	SetValueForField(doc, "MODE", "OBS_THR", i, dataLen, fields, 14, "string")
 	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	SetValueForField(doc, "MODE", "FCST_VAR", i, dataLen, fields, 15, "string")
 	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	SetValueForField(doc, "MODE", "FCST_UNITS", i, dataLen, fields, 16, "string")
 	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	SetValueForField(doc, "MODE", "FCST_LEV", i, dataLen, fields, 17, "string")
 	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	SetValueForField(doc, "MODE", "OBS_VAR", i, dataLen, fields, 18, "string")
 	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	SetValueForField(doc, "MODE", "OBS_UNITS", i, dataLen, fields, 19, "string")
 	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	SetValueForField(doc, "MODE", "OBS_LEV", i, dataLen, fields, 20, "string")
 	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *STAT_RHIST) fill_STAT_RHIST_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+	SetValueForField(doc, "MODE", "OBTYPE", i, dataLen, fields, 21, "string")
+	(*doc)["LINE_TYPE"] = "MODE_OBJ"
 }
 
 func (s *MTD_3DSINGLE) fill_MTD_3DSINGLE_Header(fields []string, doc *map[string]interface{}) {
@@ -2657,141 +2492,7 @@ func (s *MTD_3DSINGLE) fill_MTD_3DSINGLE_Header(fields []string, doc *map[string
 	(*doc)["LINE_TYPE"] = "MTD_3DSINGLE"
 }
 
-func (s *MTD_3DPAIR) fill_MTD_3DPAIR_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "MTD", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "MTD", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "MTD", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "MTD", "FCST_LEAD", i, dataLen, fields, 3, "int")
-	i++
-	SetValueForField(doc, "MTD", "FCST_VALID", i, dataLen, fields, 4, "string")
-	i++
-	SetValueForField(doc, "MTD", "OBS_LEAD", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "MTD", "OBS_VALID", i, dataLen, fields, 6, "string")
-	i++
-	SetValueForField(doc, "MTD", "T_DELTA", i, dataLen, fields, 7, "string")
-	i++
-	SetValueForField(doc, "MTD", "FCST_T_BEG", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "MTD", "FCST_T_END", i, dataLen, fields, 9, "int")
-	i++
-	SetValueForField(doc, "MTD", "FCST_RAD", i, dataLen, fields, 10, "int")
-	i++
-	SetValueForField(doc, "MTD", "FCST_THR", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "MTD", "OBS_T_BEG", i, dataLen, fields, 12, "int")
-	i++
-	SetValueForField(doc, "MTD", "OBS_T_END", i, dataLen, fields, 13, "int")
-	i++
-	SetValueForField(doc, "MTD", "OBS_RAD", i, dataLen, fields, 14, "int")
-	i++
-	SetValueForField(doc, "MTD", "OBS_THR", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "MTD", "FCST_VAR", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "MTD", "FCST_UNITS", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "MTD", "FCST_LEV", i, dataLen, fields, 18, "string")
-	i++
-	SetValueForField(doc, "MTD", "OBS_VAR", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "MTD", "OBS_UNITS", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "MTD", "OBS_LEV", i, dataLen, fields, 21, "string")
-	(*doc)["LINE_TYPE"] = "MTD_3DPAIR"
-}
-
-func (s *TCST_PROBRIRW) fill_TCST_PROBRIRW_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "TCST", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "TCST", "AMODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "TCST", "BMODEL", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "TCST", "DESC", i, dataLen, fields, 3, "string")
-	i++
-	SetValueForField(doc, "TCST", "STORM_ID", i, dataLen, fields, 4, "string")
-	i++
-	SetValueForField(doc, "TCST", "BASIN", i, dataLen, fields, 5, "string")
-	i++
-	SetValueForField(doc, "TCST", "CYCLONE", i, dataLen, fields, 6, "string")
-	i++
-	SetValueForField(doc, "TCST", "STORM_NAME", i, dataLen, fields, 7, "string")
-	i++
-	SetValueForField(doc, "TCST", "INIT", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "TCST", "VALID", i, dataLen, fields, 10, "int")
-	i++
-	SetValueForField(doc, "TCST", "INIT_MASK", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "TCST", "VALID_MASK", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "TCST", "LINE_TYPE", i, dataLen, fields, 13, "string")
-}
-
-func (s *MTD_2DSINGLE) fill_MTD_2DSINGLE_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "MTD", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "MTD", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "MTD", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "MTD", "FCST_LEAD", i, dataLen, fields, 3, "int")
-	i++
-	SetValueForField(doc, "MTD", "FCST_VALID", i, dataLen, fields, 4, "string")
-	i++
-	SetValueForField(doc, "MTD", "OBS_LEAD", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "MTD", "OBS_VALID", i, dataLen, fields, 6, "string")
-	i++
-	SetValueForField(doc, "MTD", "T_DELTA", i, dataLen, fields, 7, "string")
-	i++
-	SetValueForField(doc, "MTD", "FCST_T_BEG", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "MTD", "FCST_T_END", i, dataLen, fields, 9, "int")
-	i++
-	SetValueForField(doc, "MTD", "FCST_RAD", i, dataLen, fields, 10, "int")
-	i++
-	SetValueForField(doc, "MTD", "FCST_THR", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "MTD", "OBS_T_BEG", i, dataLen, fields, 12, "int")
-	i++
-	SetValueForField(doc, "MTD", "OBS_T_END", i, dataLen, fields, 13, "int")
-	i++
-	SetValueForField(doc, "MTD", "OBS_RAD", i, dataLen, fields, 14, "int")
-	i++
-	SetValueForField(doc, "MTD", "OBS_THR", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "MTD", "FCST_VAR", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "MTD", "FCST_UNITS", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "MTD", "FCST_LEV", i, dataLen, fields, 18, "string")
-	i++
-	SetValueForField(doc, "MTD", "OBS_VAR", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "MTD", "OBS_UNITS", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "MTD", "OBS_LEV", i, dataLen, fields, 21, "string")
-	(*doc)["LINE_TYPE"] = "MTD_2DSINGLE"
-}
-
-func (s *STAT_ORANK) fill_STAT_ORANK_Header(fields []string, doc *map[string]interface{}) {
+func (s *STAT_NBRCNT) fill_STAT_NBRCNT_Header(fields []string, doc *map[string]interface{}) {
 	dataLen := len(fields)
 	i := -1
 	// fill the met fields leaving out "" and NA values
@@ -2843,111 +2544,7 @@ func (s *STAT_ORANK) fill_STAT_ORANK_Header(fields []string, doc *map[string]int
 	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
 }
 
-func (s *STAT_ECNT) fill_STAT_ECNT_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *STAT_PHIST) fill_STAT_PHIST_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *STAT_VL1L2) fill_STAT_VL1L2_Header(fields []string, doc *map[string]interface{}) {
+func (s *STAT_RPS) fill_STAT_RPS_Header(fields []string, doc *map[string]interface{}) {
 	dataLen := len(fields)
 	i := -1
 	// fill the met fields leaving out "" and NA values
@@ -3051,160 +2648,7 @@ func (s *STAT_GENMPR) fill_STAT_GENMPR_Header(fields []string, doc *map[string]i
 	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
 }
 
-func (s *STAT_GRAD) fill_STAT_GRAD_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *STAT_SAL1L2) fill_STAT_SAL1L2_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *MODE_CTS) fill_MODE_CTS_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "MODE", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "MODE", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "MODE", "N_VALID", i, dataLen, fields, 2, "int")
-	i++
-	SetValueForField(doc, "MODE", "GRID_RES", i, dataLen, fields, 3, "float64")
-	i++
-	SetValueForField(doc, "MODE", "DESC", i, dataLen, fields, 4, "string")
-	i++
-	SetValueForField(doc, "MODE", "FCST_VALID", i, dataLen, fields, 6, "string")
-	i++
-	SetValueForField(doc, "MODE", "FCST_ACCUM", i, dataLen, fields, 7, "string")
-	i++
-	SetValueForField(doc, "MODE", "OBS_LEAD", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "MODE", "OBS_VALID", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "MODE", "OBS_ACCUM", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "MODE", "FCST_RAD", i, dataLen, fields, 11, "int")
-	i++
-	SetValueForField(doc, "MODE", "FCST_THR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "MODE", "OBS_RAD", i, dataLen, fields, 13, "int")
-	i++
-	SetValueForField(doc, "MODE", "OBS_THR", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "MODE", "FCST_VAR", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "MODE", "FCST_UNITS", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "MODE", "FCST_LEV", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "MODE", "OBS_VAR", i, dataLen, fields, 18, "string")
-	i++
-	SetValueForField(doc, "MODE", "OBS_UNITS", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "MODE", "OBS_LEV", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "MODE", "OBTYPE", i, dataLen, fields, 21, "string")
-	(*doc)["LINE_TYPE"] = "MODE_CTS"
-}
-
-func (s *TCST_TCDIAG) fill_TCST_TCDIAG_Header(fields []string, doc *map[string]interface{}) {
+func (s *TCST_PROBRIRW) fill_TCST_PROBRIRW_Header(fields []string, doc *map[string]interface{}) {
 	dataLen := len(fields)
 	i := -1
 	// fill the met fields leaving out "" and NA values
@@ -3225,7 +2669,139 @@ func (s *TCST_TCDIAG) fill_TCST_TCDIAG_Header(fields []string, doc *map[string]i
 	i++
 	SetValueForField(doc, "TCST", "STORM_NAME", i, dataLen, fields, 7, "string")
 	i++
-	SetValueForField(doc, "TCST", "INIT", i, dataLen, fields, 8, "int")
+	SetValueForField(doc, "TCST", "VALID", i, dataLen, fields, 10, "int")
+	i++
+	SetValueForField(doc, "TCST", "INIT_MASK", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "TCST", "VALID_MASK", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "TCST", "LINE_TYPE", i, dataLen, fields, 13, "string")
+}
+
+func (s *STAT_SEEPS_MPR) fill_STAT_SEEPS_MPR_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *STAT_SSIDX) fill_STAT_SSIDX_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *TCST_TCMPR) fill_TCST_TCMPR_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "TCST", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "TCST", "AMODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "TCST", "BMODEL", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "TCST", "DESC", i, dataLen, fields, 3, "string")
+	i++
+	SetValueForField(doc, "TCST", "STORM_ID", i, dataLen, fields, 4, "string")
+	i++
+	SetValueForField(doc, "TCST", "BASIN", i, dataLen, fields, 5, "string")
+	i++
+	SetValueForField(doc, "TCST", "CYCLONE", i, dataLen, fields, 6, "string")
+	i++
+	SetValueForField(doc, "TCST", "STORM_NAME", i, dataLen, fields, 7, "string")
 	i++
 	SetValueForField(doc, "TCST", "VALID", i, dataLen, fields, 10, "int")
 	i++
@@ -3236,37 +2812,554 @@ func (s *TCST_TCDIAG) fill_TCST_TCDIAG_Header(fields []string, doc *map[string]i
 	SetValueForField(doc, "TCST", "LINE_TYPE", i, dataLen, fields, 13, "string")
 }
 
-//line data struct definitions
-type STAT_PSTD struct {
-	TOTAL       int                    `json:"total"`
-	THRESH      map[string]interface{} `json:"thresh"`
-	BASER_NCL   float64                `json:"baser_ncl"`
-	BASER_NCU   float64                `json:"baser_ncu"`
-	RELIABILITY float64                `json:"reliability"`
-	RESOLUTION  float64                `json:"resolution"`
-	UNCERTAINTY float64                `json:"uncertainty"`
-	ROC_AUC     float64                `json:"roc_auc"`
-	BRIER       float64                `json:"brier"`
-	BRIER_NCL   float64                `json:"brier_ncl"`
-	BRIER_NCU   float64                `json:"brier_ncu"`
-	BRIERCL     float64                `json:"briercl"`
-	BRIERCL_NCL float64                `json:"briercl_ncl"`
-	BRIERCL_NCU float64                `json:"briercl_ncu"`
-	BSS         float64                `json:"bss"`
-	BSS_SMPL    float64                `json:"bss_smpl"`
-	THRESH_I    int                    `json:"thresh_i"`
+func (s *STAT_FHO) fill_STAT_FHO_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
 }
 
-type STAT_ECLV struct {
-	TOTAL       int                    `json:"total"`
-	BASER       float64                `json:"baser"`
-	VALUE_BASER int                    `json:"value_baser"`
-	PTS         map[string]interface{} `json:"pts"`
+func (s *STAT_ISC) fill_STAT_ISC_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *STAT_DMAP) fill_STAT_DMAP_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *STAT_PCT) fill_STAT_PCT_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *STAT_PJC) fill_STAT_PJC_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *STAT_PHIST) fill_STAT_PHIST_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *STAT_RELP) fill_STAT_RELP_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *MTD_3DPAIR) fill_MTD_3DPAIR_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "MTD", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "MTD", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "MTD", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "MTD", "FCST_LEAD", i, dataLen, fields, 3, "int")
+	i++
+	SetValueForField(doc, "MTD", "FCST_VALID", i, dataLen, fields, 4, "string")
+	i++
+	SetValueForField(doc, "MTD", "OBS_LEAD", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "MTD", "OBS_VALID", i, dataLen, fields, 6, "string")
+	i++
+	SetValueForField(doc, "MTD", "T_DELTA", i, dataLen, fields, 7, "string")
+	i++
+	SetValueForField(doc, "MTD", "FCST_T_BEG", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "MTD", "FCST_T_END", i, dataLen, fields, 9, "int")
+	i++
+	SetValueForField(doc, "MTD", "FCST_RAD", i, dataLen, fields, 10, "int")
+	i++
+	SetValueForField(doc, "MTD", "FCST_THR", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "MTD", "OBS_T_BEG", i, dataLen, fields, 12, "int")
+	i++
+	SetValueForField(doc, "MTD", "OBS_T_END", i, dataLen, fields, 13, "int")
+	i++
+	SetValueForField(doc, "MTD", "OBS_RAD", i, dataLen, fields, 14, "int")
+	i++
+	SetValueForField(doc, "MTD", "OBS_THR", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "MTD", "FCST_VAR", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "MTD", "FCST_UNITS", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "MTD", "FCST_LEV", i, dataLen, fields, 18, "string")
+	i++
+	SetValueForField(doc, "MTD", "OBS_VAR", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "MTD", "OBS_UNITS", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "MTD", "OBS_LEV", i, dataLen, fields, 21, "string")
+	(*doc)["LINE_TYPE"] = "MTD_3DPAIR"
+}
+
+//line data struct definitions
+type STAT_SEEPS_MPR struct {
+	OBS_SID  string  `json:"obs_sid"`
+	OBS_LAT  float64 `json:"obs_lat"`
+	OBS_LON  float64 `json:"obs_lon"`
+	FCST     float64 `json:"fcst"`
+	OBS      float64 `json:"obs"`
+	OBS_QC   string  `json:"obs_qc"`
+	FCST_CAT int     `json:"fcst_cat"`
+	OBS_CAT  int     `json:"obs_cat"`
+	P1       float64 `json:"p1"`
+	P2       float64 `json:"p2"`
+	T1       float64 `json:"t1"`
+	T2       float64 `json:"t2"`
+	SEEPS    float64 `json:"seeps"`
+}
+
+type STAT_ORANK struct {
+	TOTAL            int                    `json:"total"`
+	INDEX            int                    `json:"index"`
+	OBS_SID          string                 `json:"obs_sid"`
+	OBS_LAT          float64                `json:"obs_lat"`
+	OBS_LON          float64                `json:"obs_lon"`
+	OBS_LVL          float64                `json:"obs_lvl"`
+	OBS_ELV          float64                `json:"obs_elv"`
+	OBS              float64                `json:"obs"`
+	PIT              float64                `json:"pit"`
+	RANK             int                    `json:"rank"`
+	N_ENS_VLD        int                    `json:"n_ens_vld"`
+	ENS              map[string]interface{} `json:"ens"`
+	OBS_QC           string                 `json:"obs_qc"`
+	ENS_MEAN         int                    `json:"ens_mean"`
+	OBS_CLIMO_MEAN   float64                `json:"obs_climo_mean"`
+	SPREAD           float64                `json:"spread"`
+	ENS_MEAN_OERR    int                    `json:"ens_mean_oerr"`
+	SPREAD_OERR      float64                `json:"spread_oerr"`
+	SPREAD_PLUS_OERR float64                `json:"spread_plus_oerr"`
+	OBS_CLIMO_STDEV  float64                `json:"obs_climo_stdev"`
+	FCST_CLIMO_MEAN  float64                `json:"fcst_climo_mean"`
+	FCST_CLIMO_STDEV float64                `json:"fcst_climo_stdev"`
 }
 
 type STAT_RELP struct {
 	TOTAL int                    `json:"total"`
 	ENS   map[string]interface{} `json:"ens"`
+}
+
+type STAT_SSVAR struct {
+	TOTAL       int     `json:"total"`
+	N_BIN       int     `json:"n_bin"`
+	BIN_I       int     `json:"bin_i"`
+	BIN_N       int     `json:"bin_n"`
+	VAR_MIN     float64 `json:"var_min"`
+	VAR_MAX     float64 `json:"var_max"`
+	VAR_MEAN    float64 `json:"var_mean"`
+	FBAR        float64 `json:"fbar"`
+	OBAR        float64 `json:"obar"`
+	FOBAR       float64 `json:"fobar"`
+	FFBAR       float64 `json:"ffbar"`
+	OOBAR       float64 `json:"oobar"`
+	FBAR_NCL    float64 `json:"fbar_ncl"`
+	FBAR_NCU    float64 `json:"fbar_ncu"`
+	FSTDEV      float64 `json:"fstdev"`
+	FSTDEV_NCL  float64 `json:"fstdev_ncl"`
+	FSTDEV_NCU  float64 `json:"fstdev_ncu"`
+	OBAR_NCL    float64 `json:"obar_ncl"`
+	OBAR_NCU    float64 `json:"obar_ncu"`
+	OSTDEV      float64 `json:"ostdev"`
+	OSTDEV_NCL  float64 `json:"ostdev_ncl"`
+	OSTDEV_NCU  float64 `json:"ostdev_ncu"`
+	PR_CORR     float64 `json:"pr_corr"`
+	PR_CORR_NCL float64 `json:"pr_corr_ncl"`
+	PR_CORR_NCU float64 `json:"pr_corr_ncu"`
+	ME          float64 `json:"me"`
+	ME_NCL      float64 `json:"me_ncl"`
+	ME_NCU      float64 `json:"me_ncu"`
+	ESTDEV      float64 `json:"estdev"`
+	ESTDEV_NCL  float64 `json:"estdev_ncl"`
+	ESTDEV_NCU  float64 `json:"estdev_ncu"`
+	MBIAS       float64 `json:"mbias"`
+	MSE         float64 `json:"mse"`
+	BCMSE       float64 `json:"bcmse"`
+	RMSE        float64 `json:"rmse"`
+}
+
+type STAT_SSIDX struct {
+	FCST_MODEL string  `json:"fcst_model"`
+	REF_MODEL  string  `json:"ref_model"`
+	N_INIT     int     `json:"n_init"`
+	N_TERM     int     `json:"n_term"`
+	N_VLD      int     `json:"n_vld"`
+	SS_INDEX   float64 `json:"ss_index"`
+}
+
+type STAT_MPR struct {
+	TOTAL            int     `json:"total"`
+	INDEX            int     `json:"index"`
+	OBS_SID          string  `json:"obs_sid"`
+	OBS_LAT          float64 `json:"obs_lat"`
+	OBS_LON          float64 `json:"obs_lon"`
+	OBS_LVL          float64 `json:"obs_lvl"`
+	OBS_ELV          float64 `json:"obs_elv"`
+	FCST             float64 `json:"fcst"`
+	OBS              float64 `json:"obs"`
+	OBS_QC           string  `json:"obs_qc"`
+	OBS_CLIMO_MEAN   float64 `json:"obs_climo_mean"`
+	OBS_CLIMO_STDEV  float64 `json:"obs_climo_stdev"`
+	OBS_CLIMO_CDF    float64 `json:"obs_climo_cdf"`
+	FCST_CLIMO_MEAN  float64 `json:"fcst_climo_mean"`
+	FCST_CLIMO_STDEV float64 `json:"fcst_climo_stdev"`
+}
+
+type STAT_NBRCTC struct {
+	TOTAL int     `json:"total"`
+	FY_OY float64 `json:"fy_oy"`
+	FY_ON float64 `json:"fy_on"`
+	FN_OY float64 `json:"fn_oy"`
+	FN_ON float64 `json:"fn_on"`
+}
+
+type STAT_ISC struct {
+	TOTAL    int     `json:"total"`
+	TILE_DIM int     `json:"tile_dim"`
+	TILE_XLL int     `json:"tile_xll"`
+	TILE_YLL int     `json:"tile_yll"`
+	NSCALE   int     `json:"nscale"`
+	ISCALE   int     `json:"iscale"`
+	MSE      float64 `json:"mse"`
+	ISC      float64 `json:"isc"`
+	FENERGY2 float64 `json:"fenergy2"`
+	OENERGY2 float64 `json:"oenergy2"`
+	BASER    float64 `json:"baser"`
+	FBIAS    float64 `json:"fbias"`
 }
 
 type STAT_VL1L2 struct {
@@ -3286,43 +3379,68 @@ type STAT_VL1L2 struct {
 	DIR_MSE     float64 `json:"dir_mse"`
 }
 
-type TCST_TCDIAG struct {
-	TOTAL        int                    `json:"total"`
-	INDEX        int                    `json:"index"`
-	DIAG_SOURCE  float64                `json:"diag_source"`
-	TRACK_SOURCE string                 `json:"track_source"`
-	FIELD_SOURCE string                 `json:"field_source"`
-	DIAG         map[string]interface{} `json:"diag"`
+type MODE_OBJ struct {
+	OBJECT_ID                  string  `json:"object_id"`
+	OBJECT_CAT                 string  `json:"object_cat"`
+	CENTROID_X                 float64 `json:"centroid_x"`
+	CENTROID_Y                 float64 `json:"centroid_y"`
+	CENTROID_LAT               float64 `json:"centroid_lat"`
+	CENTROID_LON               float64 `json:"centroid_lon"`
+	AXIS_ANG                   float64 `json:"axis_ang"`
+	LENGTH                     float64 `json:"length"`
+	WIDTH                      float64 `json:"width"`
+	AREA                       int     `json:"area"`
+	AREA_THRESH                int     `json:"area_thresh"`
+	CURVATURE                  float64 `json:"curvature"`
+	CURVATURE_X                float64 `json:"curvature_x"`
+	CURVATURE_Y                float64 `json:"curvature_y"`
+	COMPLEXITY                 float64 `json:"complexity"`
+	INTENSITY_10               float64 `json:"intensity_10"`
+	INTENSITY_25               float64 `json:"intensity_25"`
+	INTENSITY_50               float64 `json:"intensity_50"`
+	INTENSITY_75               float64 `json:"intensity_75"`
+	INTENSITY_90               float64 `json:"intensity_90"`
+	INTENSITY_USER             float64 `json:"intensity_user"`
+	INTENSITY_SUM              float64 `json:"intensity_sum"`
+	CENTROID_DIST              float64 `json:"centroid_dist"`
+	BOUNDARY_DIST              float64 `json:"boundary_dist"`
+	CONVEX_HULL_DIST           float64 `json:"convex_hull_dist"`
+	ANGLE_DIFF                 float64 `json:"angle_diff"`
+	ASPECT_DIFF                float64 `json:"aspect_diff"`
+	AREA_RATIO                 float64 `json:"area_ratio"`
+	INTERSECTION_AREA          float64 `json:"intersection_area"`
+	UNION_AREA                 float64 `json:"union_area"`
+	SYMMETRIC_DIFF             float64 `json:"symmetric_diff"`
+	INTERSECTION_OVER_AREA     float64 `json:"intersection_over_area"`
+	CURVATURE_RATIO            float64 `json:"curvature_ratio"`
+	COMPLEXITY_RATIO           float64 `json:"complexity_ratio"`
+	PERCENTILE_INTENSITY_RATIO float64 `json:"percentile_intensity_ratio"`
+	INTEREST                   float64 `json:"interest"`
 }
 
-type STAT_ECNT struct {
-	TOTAL            int     `json:"total"`
-	N_ENS            int     `json:"n_ens"`
-	CRPS             float64 `json:"crps"`
-	CRPSS            float64 `json:"crpss"`
-	IGN              float64 `json:"ign"`
-	ME               float64 `json:"me"`
-	RMSE             float64 `json:"rmse"`
-	SPREAD           float64 `json:"spread"`
-	ME_OERR          float64 `json:"me_oerr"`
-	RMSE_OERR        float64 `json:"rmse_oerr"`
-	SPREAD_OERR      float64 `json:"spread_oerr"`
-	SPREAD_PLUS_OERR float64 `json:"spread_plus_oerr"`
-	CRPSCL           float64 `json:"crpscl"`
-	CRPS_EMP         float64 `json:"crps_emp"`
-	CRPSCL_EMP       float64 `json:"crpscl_emp"`
-	CRPSS_EMP        float64 `json:"crpss_emp"`
-	CRPS_EMP_FAIR    float64 `json:"crps_emp_fair"`
-	SPREAD_MD        float64 `json:"spread_md"`
-	MAE              float64 `json:"mae"`
-	MAE_OERR         float64 `json:"mae_oerr"`
-	BIAS_RATIO       float64 `json:"bias_ratio"`
-	N_GE_OBS         int     `json:"n_ge_obs"`
-	ME_GE_OBS        float64 `json:"me_ge_obs"`
-	N_LT_OBS         int     `json:"n_lt_obs"`
-	ME_LT_OBS        float64 `json:"me_lt_obs"`
-	IGN_CONV_OERR    float64 `json:"ign_conv_oerr"`
-	IGN_CORR_OERR    float64 `json:"ign_corr_oerr"`
+type TCST_PROBRIRW struct {
+	ALAT        float64                `json:"alat"`
+	ALON        float64                `json:"alon"`
+	BLAT        float64                `json:"blat"`
+	BLON        float64                `json:"blon"`
+	INITIALS    string                 `json:"initials"`
+	TK_ERR      float64                `json:"tk_err"`
+	X_ERR       float64                `json:"x_err"`
+	Y_ERR       float64                `json:"y_err"`
+	ADLAND      float64                `json:"adland"`
+	BDLAND      float64                `json:"bdland"`
+	RIRW_BEG    int                    `json:"rirw_beg"`
+	RIRW_END    int                    `json:"rirw_end"`
+	RIRW_WINDOW int                    `json:"rirw_window"`
+	AWIND_END   float64                `json:"awind_end"`
+	BWIND_BEG   float64                `json:"bwind_beg"`
+	BWIND_END   float64                `json:"bwind_end"`
+	BDELTA      float64                `json:"bdelta"`
+	BDELTA_MAX  float64                `json:"bdelta_max"`
+	BLEVEL_BEG  string                 `json:"blevel_beg"`
+	BLEVEL_END  string                 `json:"blevel_end"`
+	THRESH      map[string]interface{} `json:"thresh"`
+	INIT        int                    `json:"init"`
 }
 
 type STAT_SL1L2 struct {
@@ -3333,6 +3451,68 @@ type STAT_SL1L2 struct {
 	FFBAR float64 `json:"ffbar"`
 	OOBAR float64 `json:"oobar"`
 	MAE   float64 `json:"mae"`
+}
+
+type STAT_MCTS struct {
+	TOTAL      int     `json:"total"`
+	N_CAT      int     `json:"n_cat"`
+	ACC        float64 `json:"acc"`
+	ACC_NCL    float64 `json:"acc_ncl"`
+	ACC_NCU    float64 `json:"acc_ncu"`
+	ACC_BCL    float64 `json:"acc_bcl"`
+	ACC_BCU    float64 `json:"acc_bcu"`
+	HK         float64 `json:"hk"`
+	HK_BCL     float64 `json:"hk_bcl"`
+	HK_BCU     float64 `json:"hk_bcu"`
+	HSS        float64 `json:"hss"`
+	HSS_BCL    float64 `json:"hss_bcl"`
+	HSS_BCU    float64 `json:"hss_bcu"`
+	GER        float64 `json:"ger"`
+	GER_BCL    float64 `json:"ger_bcl"`
+	GER_BCU    float64 `json:"ger_bcu"`
+	HSS_EC     float64 `json:"hss_ec"`
+	HSS_EC_BCL float64 `json:"hss_ec_bcl"`
+	HSS_EC_BCU float64 `json:"hss_ec_bcu"`
+	EC_VALUE   float64 `json:"ec_value"`
+}
+
+type STAT_DMAP struct {
+	TOTAL      int     `json:"total"`
+	FY         int     `json:"fy"`
+	OY         int     `json:"oy"`
+	FBIAS      float64 `json:"fbias"`
+	BADDELEY   float64 `json:"baddeley"`
+	HAUSDORFF  float64 `json:"hausdorff"`
+	MED_FO     float64 `json:"med_fo"`
+	MED_OF     float64 `json:"med_of"`
+	MED_MIN    float64 `json:"med_min"`
+	MED_MAX    float64 `json:"med_max"`
+	MED_MEAN   float64 `json:"med_mean"`
+	FOM_FO     float64 `json:"fom_fo"`
+	FOM_OF     float64 `json:"fom_of"`
+	FOM_MIN    float64 `json:"fom_min"`
+	FOM_MAX    float64 `json:"fom_max"`
+	FOM_MEAN   float64 `json:"fom_mean"`
+	ZHU_FO     float64 `json:"zhu_fo"`
+	ZHU_OF     float64 `json:"zhu_of"`
+	ZHU_MIN    float64 `json:"zhu_min"`
+	ZHU_MAX    float64 `json:"zhu_max"`
+	ZHU_MEAN   float64 `json:"zhu_mean"`
+	G          float64 `json:"g"`
+	GBETA      float64 `json:"gbeta"`
+	BETA_VALUE float64 `json:"beta_value"`
+}
+
+type STAT_PJC struct {
+	TOTAL  int                    `json:"total"`
+	THRESH map[string]interface{} `json:"thresh"`
+}
+
+type STAT_ECLV struct {
+	TOTAL       int                    `json:"total"`
+	BASER       float64                `json:"baser"`
+	VALUE_BASER int                    `json:"value_baser"`
+	PTS         map[string]interface{} `json:"pts"`
 }
 
 type STAT_VAL1L2 struct {
@@ -3350,6 +3530,143 @@ type STAT_VAL1L2 struct {
 	DIRA_ME      float64 `json:"dira_me"`
 	DIRA_MAE     float64 `json:"dira_mae"`
 	DIRA_MSE     float64 `json:"dira_mse"`
+}
+
+type STAT_GENMPR struct {
+	TOTAL      int     `json:"total"`
+	INDEX      int     `json:"index"`
+	STORM_ID   string  `json:"storm_id"`
+	PROB_LEAD  float64 `json:"prob_lead"`
+	PROB_VAL   float64 `json:"prob_val"`
+	AGEN_INIT  string  `json:"agen_init"`
+	AGEN_FHR   string  `json:"agen_fhr"`
+	AGEN_LAT   float64 `json:"agen_lat"`
+	AGEN_LON   float64 `json:"agen_lon"`
+	AGEN_DLAND float64 `json:"agen_dland"`
+	BGEN_LAT   float64 `json:"bgen_lat"`
+	BGEN_LON   float64 `json:"bgen_lon"`
+	BGEN_DLAND float64 `json:"bgen_dland"`
+	GEN_DIST   float64 `json:"gen_dist"`
+	GEN_TDIFF  string  `json:"gen_tdiff"`
+	INIT_TDIFF string  `json:"init_tdiff"`
+	DEV_CAT    string  `json:"dev_cat"`
+	OPS_CAT    string  `json:"ops_cat"`
+}
+
+type MTD_3DPAIR struct {
+	OBJECT_ID           string  `json:"object_id"`
+	OBJECT_CAT          string  `json:"object_cat"`
+	SPACE_CENTROID_DIST float64 `json:"space_centroid_dist"`
+	TIME_CENTROID_DELTA float64 `json:"time_centroid_delta"`
+	AXIS_DIFF           float64 `json:"axis_diff"`
+	SPEED_DELTA         float64 `json:"speed_delta"`
+	DIRECTION_DIFF      float64 `json:"direction_diff"`
+	VOLUME_RATIO        float64 `json:"volume_ratio"`
+	START_TIME_DELTA    int     `json:"start_time_delta"`
+	END_TIME_DELTA      int     `json:"end_time_delta"`
+	INTERSECTION_VOLUME float64 `json:"intersection_volume"`
+	DURATION_DIFF       float64 `json:"duration_diff"`
+	INTEREST            float64 `json:"interest"`
+}
+
+type STAT_CTS struct {
+	TOTAL      int     `json:"total"`
+	BASER      float64 `json:"baser"`
+	BASER_NCL  float64 `json:"baser_ncl"`
+	BASER_NCU  float64 `json:"baser_ncu"`
+	BASER_BCL  float64 `json:"baser_bcl"`
+	BASER_BCU  float64 `json:"baser_bcu"`
+	FMEAN      float64 `json:"fmean"`
+	FMEAN_NCL  float64 `json:"fmean_ncl"`
+	FMEAN_NCU  float64 `json:"fmean_ncu"`
+	FMEAN_BCL  float64 `json:"fmean_bcl"`
+	FMEAN_BCU  float64 `json:"fmean_bcu"`
+	ACC        float64 `json:"acc"`
+	ACC_NCL    float64 `json:"acc_ncl"`
+	ACC_NCU    float64 `json:"acc_ncu"`
+	ACC_BCL    float64 `json:"acc_bcl"`
+	ACC_BCU    float64 `json:"acc_bcu"`
+	FBIAS      float64 `json:"fbias"`
+	FBIAS_BCL  float64 `json:"fbias_bcl"`
+	FBIAS_BCU  float64 `json:"fbias_bcu"`
+	PODY       float64 `json:"pody"`
+	PODY_NCL   float64 `json:"pody_ncl"`
+	PODY_NCU   float64 `json:"pody_ncu"`
+	PODY_BCL   float64 `json:"pody_bcl"`
+	PODY_BCU   float64 `json:"pody_bcu"`
+	PODN       float64 `json:"podn"`
+	PODN_NCL   float64 `json:"podn_ncl"`
+	PODN_NCU   float64 `json:"podn_ncu"`
+	PODN_BCL   float64 `json:"podn_bcl"`
+	PODN_BCU   float64 `json:"podn_bcu"`
+	POFD       float64 `json:"pofd"`
+	POFD_NCL   float64 `json:"pofd_ncl"`
+	POFD_NCU   float64 `json:"pofd_ncu"`
+	POFD_BCL   float64 `json:"pofd_bcl"`
+	POFD_BCU   float64 `json:"pofd_bcu"`
+	FAR        float64 `json:"far"`
+	FAR_NCL    float64 `json:"far_ncl"`
+	FAR_NCU    float64 `json:"far_ncu"`
+	FAR_BCL    float64 `json:"far_bcl"`
+	FAR_BCU    float64 `json:"far_bcu"`
+	CSI        float64 `json:"csi"`
+	CSI_NCL    float64 `json:"csi_ncl"`
+	CSI_NCU    float64 `json:"csi_ncu"`
+	CSI_BCL    float64 `json:"csi_bcl"`
+	CSI_BCU    float64 `json:"csi_bcu"`
+	GSS        float64 `json:"gss"`
+	GSS_BCL    float64 `json:"gss_bcl"`
+	GSS_BCU    float64 `json:"gss_bcu"`
+	HK         float64 `json:"hk"`
+	HK_NCL     float64 `json:"hk_ncl"`
+	HK_NCU     float64 `json:"hk_ncu"`
+	HK_BCL     float64 `json:"hk_bcl"`
+	HK_BCU     float64 `json:"hk_bcu"`
+	HSS        float64 `json:"hss"`
+	HSS_BCL    float64 `json:"hss_bcl"`
+	HSS_BCU    float64 `json:"hss_bcu"`
+	ODDS       float64 `json:"odds"`
+	ODDS_NCL   float64 `json:"odds_ncl"`
+	ODDS_NCU   float64 `json:"odds_ncu"`
+	ODDS_BCL   float64 `json:"odds_bcl"`
+	ODDS_BCU   float64 `json:"odds_bcu"`
+	LODDS      float64 `json:"lodds"`
+	LODDS_NCL  float64 `json:"lodds_ncl"`
+	LODDS_NCU  float64 `json:"lodds_ncu"`
+	LODDS_BCL  float64 `json:"lodds_bcl"`
+	LODDS_BCU  float64 `json:"lodds_bcu"`
+	ORSS       float64 `json:"orss"`
+	ORSS_NCL   float64 `json:"orss_ncl"`
+	ORSS_NCU   float64 `json:"orss_ncu"`
+	ORSS_BCL   float64 `json:"orss_bcl"`
+	ORSS_BCU   float64 `json:"orss_bcu"`
+	EDS        float64 `json:"eds"`
+	EDS_NCL    float64 `json:"eds_ncl"`
+	EDS_NCU    float64 `json:"eds_ncu"`
+	EDS_BCL    float64 `json:"eds_bcl"`
+	EDS_BCU    float64 `json:"eds_bcu"`
+	SEDS       float64 `json:"seds"`
+	SEDS_NCL   float64 `json:"seds_ncl"`
+	SEDS_NCU   float64 `json:"seds_ncu"`
+	SEDS_BCL   float64 `json:"seds_bcl"`
+	SEDS_BCU   float64 `json:"seds_bcu"`
+	EDI        float64 `json:"edi"`
+	EDI_NCL    float64 `json:"edi_ncl"`
+	EDI_NCU    float64 `json:"edi_ncu"`
+	EDI_BCL    float64 `json:"edi_bcl"`
+	EDI_BCU    float64 `json:"edi_bcu"`
+	SEDI       float64 `json:"sedi"`
+	SEDI_NCL   float64 `json:"sedi_ncl"`
+	SEDI_NCU   float64 `json:"sedi_ncu"`
+	SEDI_BCL   float64 `json:"sedi_bcl"`
+	SEDI_BCU   float64 `json:"sedi_bcu"`
+	BAGSS      float64 `json:"bagss"`
+	BAGSS_BCL  float64 `json:"bagss_bcl"`
+	BAGSS_BCU  float64 `json:"bagss_bcu"`
+	HSS_EC     float64 `json:"hss_ec"`
+	HSS_EC_BCL float64 `json:"hss_ec_bcl"`
+	HSS_EC_BCU float64 `json:"hss_ec_bcu"`
+	EC_VALUE   float64 `json:"ec_value"`
 }
 
 type TCST_TCMPR struct {
@@ -3424,6 +3741,7 @@ type TCST_TCMPR struct {
 	TRACK_STDEV    float64 `json:"track_stdev"`
 	MSLP_STDEV     float64 `json:"mslp_stdev"`
 	MAX_WIND_STDEV float64 `json:"max_wind_stdev"`
+	INIT           int     `json:"init"`
 }
 
 type STAT_SEEPS struct {
@@ -3445,103 +3763,19 @@ type STAT_SEEPS struct {
 	SEEPS     float64 `json:"seeps"`
 }
 
-type STAT_SEEPS_MPR struct {
-	OBS_SID  string  `json:"obs_sid"`
-	OBS_LAT  float64 `json:"obs_lat"`
-	OBS_LON  float64 `json:"obs_lon"`
-	FCST     float64 `json:"fcst"`
-	OBS      float64 `json:"obs"`
-	OBS_QC   string  `json:"obs_qc"`
-	FCST_CAT int     `json:"fcst_cat"`
-	OBS_CAT  int     `json:"obs_cat"`
-	P1       float64 `json:"p1"`
-	P2       float64 `json:"p2"`
-	T1       float64 `json:"t1"`
-	T2       float64 `json:"t2"`
-	SEEPS    float64 `json:"seeps"`
-}
-
-type STAT_NBRCTC struct {
-	TOTAL int     `json:"total"`
-	FY_OY float64 `json:"fy_oy"`
-	FY_ON float64 `json:"fy_on"`
-	FN_OY float64 `json:"fn_oy"`
-	FN_ON float64 `json:"fn_on"`
-}
-
-type STAT_ORANK struct {
-	TOTAL            int                    `json:"total"`
-	INDEX            int                    `json:"index"`
-	OBS_SID          string                 `json:"obs_sid"`
-	OBS_LAT          float64                `json:"obs_lat"`
-	OBS_LON          float64                `json:"obs_lon"`
-	OBS_LVL          float64                `json:"obs_lvl"`
-	OBS_ELV          float64                `json:"obs_elv"`
-	OBS              float64                `json:"obs"`
-	PIT              float64                `json:"pit"`
-	RANK             int                    `json:"rank"`
-	N_ENS_VLD        int                    `json:"n_ens_vld"`
-	ENS              map[string]interface{} `json:"ens"`
-	OBS_QC           string                 `json:"obs_qc"`
-	ENS_MEAN         int                    `json:"ens_mean"`
-	OBS_CLIMO_MEAN   float64                `json:"obs_climo_mean"`
-	SPREAD           float64                `json:"spread"`
-	ENS_MEAN_OERR    int                    `json:"ens_mean_oerr"`
-	SPREAD_OERR      float64                `json:"spread_oerr"`
-	SPREAD_PLUS_OERR float64                `json:"spread_plus_oerr"`
-	OBS_CLIMO_STDEV  float64                `json:"obs_climo_stdev"`
-	FCST_CLIMO_MEAN  float64                `json:"fcst_climo_mean"`
-	FCST_CLIMO_STDEV float64                `json:"fcst_climo_stdev"`
-}
-
-type STAT_PRC struct {
-	TOTAL  int                    `json:"total"`
-	THRESH map[string]interface{} `json:"thresh"`
-}
-
-type STAT_RPS struct {
-	TOTAL     int     `json:"total"`
-	N_PROB    int     `json:"n_prob"`
-	RPS_REL   float64 `json:"rps_rel"`
-	RPS_RES   float64 `json:"rps_res"`
-	RPS_UNC   float64 `json:"rps_unc"`
-	RPS       float64 `json:"rps"`
-	RPSS      float64 `json:"rpss"`
-	RPSS_SMPL float64 `json:"rpss_smpl"`
-	RPS_COMP  float64 `json:"rps_comp"`
-}
-
-type MTD_3DSINGLE struct {
-	OBJECT_ID       string  `json:"object_id"`
-	OBJECT_CAT      string  `json:"object_cat"`
-	CENTROID_X      float64 `json:"centroid_x"`
-	CENTROID_Y      float64 `json:"centroid_y"`
-	CENTROID_T      float64 `json:"centroid_t"`
-	CENTROID_LAT    float64 `json:"centroid_lat"`
-	CENTROID_LON    float64 `json:"centroid_lon"`
-	X_DOT           float64 `json:"x_dot"`
-	Y_DOT           float64 `json:"y_dot"`
-	AXIS_ANG        float64 `json:"axis_ang"`
-	VOLUME          int     `json:"volume"`
-	START_TIME      int     `json:"start_time"`
-	END_TIME        int     `json:"end_time"`
-	CDIST_TRAVELLED float64 `json:"cdist_travelled"`
-	INTENSITY_10    float64 `json:"intensity_10"`
-	INTENSITY_25    float64 `json:"intensity_25"`
-	INTENSITY_50    float64 `json:"intensity_50"`
-	INTENSITY_75    float64 `json:"intensity_75"`
-	INTENSITY_90    float64 `json:"intensity_90"`
-	INTENSITY_USER  float64 `json:"intensity_user"`
-}
-
-type STAT_PCT struct {
-	TOTAL  int                    `json:"total"`
-	THRESH map[string]interface{} `json:"thresh"`
-}
-
 type STAT_RHIST struct {
 	TOTAL int                    `json:"total"`
 	RANK  map[string]interface{} `json:"rank"`
+}
+
+type STAT_SAL1L2 struct {
+	TOTAL  int     `json:"total"`
+	FABAR  float64 `json:"fabar"`
+	OABAR  float64 `json:"oabar"`
+	FOABAR float64 `json:"foabar"`
+	FFABAR float64 `json:"ffabar"`
+	OOABAR float64 `json:"ooabar"`
+	MAE    float64 `json:"mae"`
 }
 
 type STAT_VCNT struct {
@@ -3623,36 +3857,6 @@ type STAT_VCNT struct {
 	DIR_RMSE_BCU         float64 `json:"dir_rmse_bcu"`
 }
 
-type STAT_GENMPR struct {
-	TOTAL      int     `json:"total"`
-	INDEX      int     `json:"index"`
-	STORM_ID   string  `json:"storm_id"`
-	PROB_LEAD  float64 `json:"prob_lead"`
-	PROB_VAL   float64 `json:"prob_val"`
-	AGEN_INIT  string  `json:"agen_init"`
-	AGEN_FHR   string  `json:"agen_fhr"`
-	AGEN_LAT   float64 `json:"agen_lat"`
-	AGEN_LON   float64 `json:"agen_lon"`
-	AGEN_DLAND float64 `json:"agen_dland"`
-	BGEN_LAT   float64 `json:"bgen_lat"`
-	BGEN_LON   float64 `json:"bgen_lon"`
-	BGEN_DLAND float64 `json:"bgen_dland"`
-	GEN_DIST   float64 `json:"gen_dist"`
-	GEN_TDIFF  string  `json:"gen_tdiff"`
-	INIT_TDIFF string  `json:"init_tdiff"`
-	DEV_CAT    string  `json:"dev_cat"`
-	OPS_CAT    string  `json:"ops_cat"`
-}
-
-type STAT_SSIDX struct {
-	FCST_MODEL string  `json:"fcst_model"`
-	REF_MODEL  string  `json:"ref_model"`
-	N_INIT     int     `json:"n_init"`
-	N_TERM     int     `json:"n_term"`
-	N_VLD      int     `json:"n_vld"`
-	SS_INDEX   float64 `json:"ss_index"`
-}
-
 type MODE_CTS struct {
 	FIELD string  `json:"field"`
 	TOTAL int     `json:"total"`
@@ -3682,88 +3886,33 @@ type MODE_CTS struct {
 	BAGSS float64 `json:"bagss"`
 }
 
-type STAT_ISC struct {
-	TOTAL    int     `json:"total"`
-	TILE_DIM int     `json:"tile_dim"`
-	TILE_XLL int     `json:"tile_xll"`
-	TILE_YLL int     `json:"tile_yll"`
-	NSCALE   int     `json:"nscale"`
-	ISCALE   int     `json:"iscale"`
-	MSE      float64 `json:"mse"`
-	ISC      float64 `json:"isc"`
-	FENERGY2 float64 `json:"fenergy2"`
-	OENERGY2 float64 `json:"oenergy2"`
-	BASER    float64 `json:"baser"`
-	FBIAS    float64 `json:"fbias"`
+type MTD_3DSINGLE struct {
+	OBJECT_ID       string  `json:"object_id"`
+	OBJECT_CAT      string  `json:"object_cat"`
+	CENTROID_X      float64 `json:"centroid_x"`
+	CENTROID_Y      float64 `json:"centroid_y"`
+	CENTROID_T      float64 `json:"centroid_t"`
+	CENTROID_LAT    float64 `json:"centroid_lat"`
+	CENTROID_LON    float64 `json:"centroid_lon"`
+	X_DOT           float64 `json:"x_dot"`
+	Y_DOT           float64 `json:"y_dot"`
+	AXIS_ANG        float64 `json:"axis_ang"`
+	VOLUME          int     `json:"volume"`
+	START_TIME      int     `json:"start_time"`
+	END_TIME        int     `json:"end_time"`
+	CDIST_TRAVELLED float64 `json:"cdist_travelled"`
+	INTENSITY_10    float64 `json:"intensity_10"`
+	INTENSITY_25    float64 `json:"intensity_25"`
+	INTENSITY_50    float64 `json:"intensity_50"`
+	INTENSITY_75    float64 `json:"intensity_75"`
+	INTENSITY_90    float64 `json:"intensity_90"`
+	INTENSITY_USER  float64 `json:"intensity_user"`
 }
 
-type STAT_MCTS struct {
-	TOTAL      int     `json:"total"`
-	N_CAT      int     `json:"n_cat"`
-	ACC        float64 `json:"acc"`
-	ACC_NCL    float64 `json:"acc_ncl"`
-	ACC_NCU    float64 `json:"acc_ncu"`
-	ACC_BCL    float64 `json:"acc_bcl"`
-	ACC_BCU    float64 `json:"acc_bcu"`
-	HK         float64 `json:"hk"`
-	HK_BCL     float64 `json:"hk_bcl"`
-	HK_BCU     float64 `json:"hk_bcu"`
-	HSS        float64 `json:"hss"`
-	HSS_BCL    float64 `json:"hss_bcl"`
-	HSS_BCU    float64 `json:"hss_bcu"`
-	GER        float64 `json:"ger"`
-	GER_BCL    float64 `json:"ger_bcl"`
-	GER_BCU    float64 `json:"ger_bcu"`
-	HSS_EC     float64 `json:"hss_ec"`
-	HSS_EC_BCL float64 `json:"hss_ec_bcl"`
-	HSS_EC_BCU float64 `json:"hss_ec_bcu"`
-	EC_VALUE   float64 `json:"ec_value"`
-}
-
-type STAT_PHIST struct {
+type STAT_MCTC struct {
 	TOTAL    int                    `json:"total"`
-	BIN_SIZE int                    `json:"bin_size"`
-	BIN      map[string]interface{} `json:"bin"`
-}
-
-type MTD_3DPAIR struct {
-	OBJECT_ID           string  `json:"object_id"`
-	OBJECT_CAT          string  `json:"object_cat"`
-	SPACE_CENTROID_DIST float64 `json:"space_centroid_dist"`
-	TIME_CENTROID_DELTA float64 `json:"time_centroid_delta"`
-	AXIS_DIFF           float64 `json:"axis_diff"`
-	SPEED_DELTA         float64 `json:"speed_delta"`
-	DIRECTION_DIFF      float64 `json:"direction_diff"`
-	VOLUME_RATIO        float64 `json:"volume_ratio"`
-	START_TIME_DELTA    int     `json:"start_time_delta"`
-	END_TIME_DELTA      int     `json:"end_time_delta"`
-	INTERSECTION_VOLUME float64 `json:"intersection_volume"`
-	DURATION_DIFF       float64 `json:"duration_diff"`
-	INTEREST            float64 `json:"interest"`
-}
-
-type TCST_PROBRIRW struct {
-	ALAT        float64                `json:"alat"`
-	ALON        float64                `json:"alon"`
-	BLAT        float64                `json:"blat"`
-	BLON        float64                `json:"blon"`
-	INITIALS    string                 `json:"initials"`
-	TK_ERR      float64                `json:"tk_err"`
-	X_ERR       float64                `json:"x_err"`
-	Y_ERR       float64                `json:"y_err"`
-	ADLAND      float64                `json:"adland"`
-	BDLAND      float64                `json:"bdland"`
-	RIRW_BEG    int                    `json:"rirw_beg"`
-	RIRW_END    int                    `json:"rirw_end"`
-	RIRW_WINDOW int                    `json:"rirw_window"`
-	AWIND_END   float64                `json:"awind_end"`
-	BWIND_BEG   float64                `json:"bwind_beg"`
-	BWIND_END   float64                `json:"bwind_end"`
-	BDELTA      float64                `json:"bdelta"`
-	BDELTA_MAX  float64                `json:"bdelta_max"`
-	BLEVEL_BEG  string                 `json:"blevel_beg"`
-	BLEVEL_END  string                 `json:"blevel_end"`
-	THRESH      map[string]interface{} `json:"thresh"`
+	CAT      map[string]interface{} `json:"cat"`
+	EC_VALUE float64                `json:"ec_value"`
 }
 
 type STAT_FHO struct {
@@ -3771,24 +3920,6 @@ type STAT_FHO struct {
 	F_RATE float64 `json:"f_rate"`
 	H_RATE float64 `json:"h_rate"`
 	O_RATE float64 `json:"o_rate"`
-}
-
-type STAT_MPR struct {
-	TOTAL            int     `json:"total"`
-	INDEX            int     `json:"index"`
-	OBS_SID          string  `json:"obs_sid"`
-	OBS_LAT          float64 `json:"obs_lat"`
-	OBS_LON          float64 `json:"obs_lon"`
-	OBS_LVL          float64 `json:"obs_lvl"`
-	OBS_ELV          float64 `json:"obs_elv"`
-	FCST             float64 `json:"fcst"`
-	OBS              float64 `json:"obs"`
-	OBS_QC           string  `json:"obs_qc"`
-	OBS_CLIMO_MEAN   float64 `json:"obs_climo_mean"`
-	OBS_CLIMO_STDEV  float64 `json:"obs_climo_stdev"`
-	OBS_CLIMO_CDF    float64 `json:"obs_climo_cdf"`
-	FCST_CLIMO_MEAN  float64 `json:"fcst_climo_mean"`
-	FCST_CLIMO_STDEV float64 `json:"fcst_climo_stdev"`
 }
 
 type STAT_NBRCTS struct {
@@ -3887,19 +4018,75 @@ type STAT_NBRCTS struct {
 	BAGSS_BCU float64 `json:"bagss_bcu"`
 }
 
-type STAT_PJC struct {
+type STAT_GRAD struct {
+	TOTAL      int     `json:"total"`
+	FGBAR      float64 `json:"fgbar"`
+	OGBAR      float64 `json:"ogbar"`
+	MGBAR      float64 `json:"mgbar"`
+	EGBAR      float64 `json:"egbar"`
+	S1         float64 `json:"s1"`
+	S1_OG      float64 `json:"s1_og"`
+	FGOG_RATIO float64 `json:"fgog_ratio"`
+	DX         float64 `json:"dx"`
+	DY         float64 `json:"dy"`
+}
+
+type STAT_PCT struct {
 	TOTAL  int                    `json:"total"`
 	THRESH map[string]interface{} `json:"thresh"`
 }
 
-type STAT_SAL1L2 struct {
-	TOTAL  int     `json:"total"`
-	FABAR  float64 `json:"fabar"`
-	OABAR  float64 `json:"oabar"`
-	FOABAR float64 `json:"foabar"`
-	FFABAR float64 `json:"ffabar"`
-	OOABAR float64 `json:"ooabar"`
-	MAE    float64 `json:"mae"`
+type STAT_PRC struct {
+	TOTAL  int                    `json:"total"`
+	THRESH map[string]interface{} `json:"thresh"`
+}
+
+type STAT_ECNT struct {
+	TOTAL            int     `json:"total"`
+	N_ENS            int     `json:"n_ens"`
+	CRPS             float64 `json:"crps"`
+	CRPSS            float64 `json:"crpss"`
+	IGN              float64 `json:"ign"`
+	ME               float64 `json:"me"`
+	RMSE             float64 `json:"rmse"`
+	SPREAD           float64 `json:"spread"`
+	ME_OERR          float64 `json:"me_oerr"`
+	RMSE_OERR        float64 `json:"rmse_oerr"`
+	SPREAD_OERR      float64 `json:"spread_oerr"`
+	SPREAD_PLUS_OERR float64 `json:"spread_plus_oerr"`
+	CRPSCL           float64 `json:"crpscl"`
+	CRPS_EMP         float64 `json:"crps_emp"`
+	CRPSCL_EMP       float64 `json:"crpscl_emp"`
+	CRPSS_EMP        float64 `json:"crpss_emp"`
+	CRPS_EMP_FAIR    float64 `json:"crps_emp_fair"`
+	SPREAD_MD        float64 `json:"spread_md"`
+	MAE              float64 `json:"mae"`
+	MAE_OERR         float64 `json:"mae_oerr"`
+	BIAS_RATIO       float64 `json:"bias_ratio"`
+	N_GE_OBS         int     `json:"n_ge_obs"`
+	ME_GE_OBS        float64 `json:"me_ge_obs"`
+	N_LT_OBS         int     `json:"n_lt_obs"`
+	ME_LT_OBS        float64 `json:"me_lt_obs"`
+	IGN_CONV_OERR    float64 `json:"ign_conv_oerr"`
+	IGN_CORR_OERR    float64 `json:"ign_corr_oerr"`
+}
+
+type MTD_2DSINGLE struct {
+	OBJECT_ID      string  `json:"object_id"`
+	OBJECT_CAT     string  `json:"object_cat"`
+	TIME_INDEX     int     `json:"time_index"`
+	AREA           int     `json:"area"`
+	CENTROID_X     float64 `json:"centroid_x"`
+	CENTROID_Y     float64 `json:"centroid_y"`
+	CENTROID_LAT   float64 `json:"centroid_lat"`
+	CENTROID_LON   float64 `json:"centroid_lon"`
+	AXIS_ANG       float64 `json:"axis_ang"`
+	INTENSITY_10   float64 `json:"intensity_10"`
+	INTENSITY_25   float64 `json:"intensity_25"`
+	INTENSITY_50   float64 `json:"intensity_50"`
+	INTENSITY_75   float64 `json:"intensity_75"`
+	INTENSITY_90   float64 `json:"intensity_90"`
+	INTENSITY_USER float64 `json:"intensity_user"`
 }
 
 type STAT_CNT struct {
@@ -4005,119 +4192,46 @@ type STAT_CNT struct {
 	SI_BCU               float64 `json:"si_bcu"`
 }
 
-type STAT_CTC struct {
-	TOTAL    int     `json:"total"`
-	FY_OY    float64 `json:"fy_oy"`
-	FY_ON    float64 `json:"fy_on"`
-	FN_OY    float64 `json:"fn_oy"`
-	FN_ON    float64 `json:"fn_on"`
-	EC_VALUE float64 `json:"ec_value"`
+type STAT_PSTD struct {
+	TOTAL       int                    `json:"total"`
+	THRESH      map[string]interface{} `json:"thresh"`
+	BASER_NCL   float64                `json:"baser_ncl"`
+	BASER_NCU   float64                `json:"baser_ncu"`
+	RELIABILITY float64                `json:"reliability"`
+	RESOLUTION  float64                `json:"resolution"`
+	UNCERTAINTY float64                `json:"uncertainty"`
+	ROC_AUC     float64                `json:"roc_auc"`
+	BRIER       float64                `json:"brier"`
+	BRIER_NCL   float64                `json:"brier_ncl"`
+	BRIER_NCU   float64                `json:"brier_ncu"`
+	BRIERCL     float64                `json:"briercl"`
+	BRIERCL_NCL float64                `json:"briercl_ncl"`
+	BRIERCL_NCU float64                `json:"briercl_ncu"`
+	BSS         float64                `json:"bss"`
+	BSS_SMPL    float64                `json:"bss_smpl"`
+	THRESH_I    int                    `json:"thresh_i"`
 }
 
-type STAT_CTS struct {
-	TOTAL      int     `json:"total"`
-	BASER      float64 `json:"baser"`
-	BASER_NCL  float64 `json:"baser_ncl"`
-	BASER_NCU  float64 `json:"baser_ncu"`
-	BASER_BCL  float64 `json:"baser_bcl"`
-	BASER_BCU  float64 `json:"baser_bcu"`
-	FMEAN      float64 `json:"fmean"`
-	FMEAN_NCL  float64 `json:"fmean_ncl"`
-	FMEAN_NCU  float64 `json:"fmean_ncu"`
-	FMEAN_BCL  float64 `json:"fmean_bcl"`
-	FMEAN_BCU  float64 `json:"fmean_bcu"`
-	ACC        float64 `json:"acc"`
-	ACC_NCL    float64 `json:"acc_ncl"`
-	ACC_NCU    float64 `json:"acc_ncu"`
-	ACC_BCL    float64 `json:"acc_bcl"`
-	ACC_BCU    float64 `json:"acc_bcu"`
-	FBIAS      float64 `json:"fbias"`
-	FBIAS_BCL  float64 `json:"fbias_bcl"`
-	FBIAS_BCU  float64 `json:"fbias_bcu"`
-	PODY       float64 `json:"pody"`
-	PODY_NCL   float64 `json:"pody_ncl"`
-	PODY_NCU   float64 `json:"pody_ncu"`
-	PODY_BCL   float64 `json:"pody_bcl"`
-	PODY_BCU   float64 `json:"pody_bcu"`
-	PODN       float64 `json:"podn"`
-	PODN_NCL   float64 `json:"podn_ncl"`
-	PODN_NCU   float64 `json:"podn_ncu"`
-	PODN_BCL   float64 `json:"podn_bcl"`
-	PODN_BCU   float64 `json:"podn_bcu"`
-	POFD       float64 `json:"pofd"`
-	POFD_NCL   float64 `json:"pofd_ncl"`
-	POFD_NCU   float64 `json:"pofd_ncu"`
-	POFD_BCL   float64 `json:"pofd_bcl"`
-	POFD_BCU   float64 `json:"pofd_bcu"`
-	FAR        float64 `json:"far"`
-	FAR_NCL    float64 `json:"far_ncl"`
-	FAR_NCU    float64 `json:"far_ncu"`
-	FAR_BCL    float64 `json:"far_bcl"`
-	FAR_BCU    float64 `json:"far_bcu"`
-	CSI        float64 `json:"csi"`
-	CSI_NCL    float64 `json:"csi_ncl"`
-	CSI_NCU    float64 `json:"csi_ncu"`
-	CSI_BCL    float64 `json:"csi_bcl"`
-	CSI_BCU    float64 `json:"csi_bcu"`
-	GSS        float64 `json:"gss"`
-	GSS_BCL    float64 `json:"gss_bcl"`
-	GSS_BCU    float64 `json:"gss_bcu"`
-	HK         float64 `json:"hk"`
-	HK_NCL     float64 `json:"hk_ncl"`
-	HK_NCU     float64 `json:"hk_ncu"`
-	HK_BCL     float64 `json:"hk_bcl"`
-	HK_BCU     float64 `json:"hk_bcu"`
-	HSS        float64 `json:"hss"`
-	HSS_BCL    float64 `json:"hss_bcl"`
-	HSS_BCU    float64 `json:"hss_bcu"`
-	ODDS       float64 `json:"odds"`
-	ODDS_NCL   float64 `json:"odds_ncl"`
-	ODDS_NCU   float64 `json:"odds_ncu"`
-	ODDS_BCL   float64 `json:"odds_bcl"`
-	ODDS_BCU   float64 `json:"odds_bcu"`
-	LODDS      float64 `json:"lodds"`
-	LODDS_NCL  float64 `json:"lodds_ncl"`
-	LODDS_NCU  float64 `json:"lodds_ncu"`
-	LODDS_BCL  float64 `json:"lodds_bcl"`
-	LODDS_BCU  float64 `json:"lodds_bcu"`
-	ORSS       float64 `json:"orss"`
-	ORSS_NCL   float64 `json:"orss_ncl"`
-	ORSS_NCU   float64 `json:"orss_ncu"`
-	ORSS_BCL   float64 `json:"orss_bcl"`
-	ORSS_BCU   float64 `json:"orss_bcu"`
-	EDS        float64 `json:"eds"`
-	EDS_NCL    float64 `json:"eds_ncl"`
-	EDS_NCU    float64 `json:"eds_ncu"`
-	EDS_BCL    float64 `json:"eds_bcl"`
-	EDS_BCU    float64 `json:"eds_bcu"`
-	SEDS       float64 `json:"seds"`
-	SEDS_NCL   float64 `json:"seds_ncl"`
-	SEDS_NCU   float64 `json:"seds_ncu"`
-	SEDS_BCL   float64 `json:"seds_bcl"`
-	SEDS_BCU   float64 `json:"seds_bcu"`
-	EDI        float64 `json:"edi"`
-	EDI_NCL    float64 `json:"edi_ncl"`
-	EDI_NCU    float64 `json:"edi_ncu"`
-	EDI_BCL    float64 `json:"edi_bcl"`
-	EDI_BCU    float64 `json:"edi_bcu"`
-	SEDI       float64 `json:"sedi"`
-	SEDI_NCL   float64 `json:"sedi_ncl"`
-	SEDI_NCU   float64 `json:"sedi_ncu"`
-	SEDI_BCL   float64 `json:"sedi_bcl"`
-	SEDI_BCU   float64 `json:"sedi_bcu"`
-	BAGSS      float64 `json:"bagss"`
-	BAGSS_BCL  float64 `json:"bagss_bcl"`
-	BAGSS_BCU  float64 `json:"bagss_bcu"`
-	HSS_EC     float64 `json:"hss_ec"`
-	HSS_EC_BCL float64 `json:"hss_ec_bcl"`
-	HSS_EC_BCU float64 `json:"hss_ec_bcu"`
-	EC_VALUE   float64 `json:"ec_value"`
+type STAT_RPS struct {
+	TOTAL     int     `json:"total"`
+	N_PROB    int     `json:"n_prob"`
+	RPS_REL   float64 `json:"rps_rel"`
+	RPS_RES   float64 `json:"rps_res"`
+	RPS_UNC   float64 `json:"rps_unc"`
+	RPS       float64 `json:"rps"`
+	RPSS      float64 `json:"rpss"`
+	RPSS_SMPL float64 `json:"rpss_smpl"`
+	RPS_COMP  float64 `json:"rps_comp"`
 }
 
-type STAT_MCTC struct {
-	TOTAL    int                    `json:"total"`
-	CAT      map[string]interface{} `json:"cat"`
-	EC_VALUE float64                `json:"ec_value"`
+type TCST_TCDIAG struct {
+	TOTAL        int                    `json:"total"`
+	INDEX        int                    `json:"index"`
+	DIAG_SOURCE  float64                `json:"diag_source"`
+	TRACK_SOURCE string                 `json:"track_source"`
+	FIELD_SOURCE string                 `json:"field_source"`
+	DIAG         map[string]interface{} `json:"diag"`
+	INIT         int                    `json:"init"`
 }
 
 type STAT_NBRCNT struct {
@@ -4142,196 +4256,333 @@ type STAT_NBRCNT struct {
 	O_RATE_BCU float64 `json:"o_rate_bcu"`
 }
 
-type STAT_GRAD struct {
-	TOTAL      int     `json:"total"`
-	FGBAR      float64 `json:"fgbar"`
-	OGBAR      float64 `json:"ogbar"`
-	MGBAR      float64 `json:"mgbar"`
-	EGBAR      float64 `json:"egbar"`
-	S1         float64 `json:"s1"`
-	S1_OG      float64 `json:"s1_og"`
-	FGOG_RATIO float64 `json:"fgog_ratio"`
-	DX         float64 `json:"dx"`
-	DY         float64 `json:"dy"`
+type STAT_PHIST struct {
+	TOTAL    int                    `json:"total"`
+	BIN_SIZE int                    `json:"bin_size"`
+	BIN      map[string]interface{} `json:"bin"`
 }
 
-type STAT_DMAP struct {
-	TOTAL      int     `json:"total"`
-	FY         int     `json:"fy"`
-	OY         int     `json:"oy"`
-	FBIAS      float64 `json:"fbias"`
-	BADDELEY   float64 `json:"baddeley"`
-	HAUSDORFF  float64 `json:"hausdorff"`
-	MED_FO     float64 `json:"med_fo"`
-	MED_OF     float64 `json:"med_of"`
-	MED_MIN    float64 `json:"med_min"`
-	MED_MAX    float64 `json:"med_max"`
-	MED_MEAN   float64 `json:"med_mean"`
-	FOM_FO     float64 `json:"fom_fo"`
-	FOM_OF     float64 `json:"fom_of"`
-	FOM_MIN    float64 `json:"fom_min"`
-	FOM_MAX    float64 `json:"fom_max"`
-	FOM_MEAN   float64 `json:"fom_mean"`
-	ZHU_FO     float64 `json:"zhu_fo"`
-	ZHU_OF     float64 `json:"zhu_of"`
-	ZHU_MIN    float64 `json:"zhu_min"`
-	ZHU_MAX    float64 `json:"zhu_max"`
-	ZHU_MEAN   float64 `json:"zhu_mean"`
-	G          float64 `json:"g"`
-	GBETA      float64 `json:"gbeta"`
-	BETA_VALUE float64 `json:"beta_value"`
-}
-
-type MODE_OBJ struct {
-	OBJECT_ID                  string  `json:"object_id"`
-	OBJECT_CAT                 string  `json:"object_cat"`
-	CENTROID_X                 float64 `json:"centroid_x"`
-	CENTROID_Y                 float64 `json:"centroid_y"`
-	CENTROID_LAT               float64 `json:"centroid_lat"`
-	CENTROID_LON               float64 `json:"centroid_lon"`
-	AXIS_ANG                   float64 `json:"axis_ang"`
-	LENGTH                     float64 `json:"length"`
-	WIDTH                      float64 `json:"width"`
-	AREA                       int     `json:"area"`
-	AREA_THRESH                int     `json:"area_thresh"`
-	CURVATURE                  float64 `json:"curvature"`
-	CURVATURE_X                float64 `json:"curvature_x"`
-	CURVATURE_Y                float64 `json:"curvature_y"`
-	COMPLEXITY                 float64 `json:"complexity"`
-	INTENSITY_10               float64 `json:"intensity_10"`
-	INTENSITY_25               float64 `json:"intensity_25"`
-	INTENSITY_50               float64 `json:"intensity_50"`
-	INTENSITY_75               float64 `json:"intensity_75"`
-	INTENSITY_90               float64 `json:"intensity_90"`
-	INTENSITY_USER             float64 `json:"intensity_user"`
-	INTENSITY_SUM              float64 `json:"intensity_sum"`
-	CENTROID_DIST              float64 `json:"centroid_dist"`
-	BOUNDARY_DIST              float64 `json:"boundary_dist"`
-	CONVEX_HULL_DIST           float64 `json:"convex_hull_dist"`
-	ANGLE_DIFF                 float64 `json:"angle_diff"`
-	ASPECT_DIFF                float64 `json:"aspect_diff"`
-	AREA_RATIO                 float64 `json:"area_ratio"`
-	INTERSECTION_AREA          float64 `json:"intersection_area"`
-	UNION_AREA                 float64 `json:"union_area"`
-	SYMMETRIC_DIFF             float64 `json:"symmetric_diff"`
-	INTERSECTION_OVER_AREA     float64 `json:"intersection_over_area"`
-	CURVATURE_RATIO            float64 `json:"curvature_ratio"`
-	COMPLEXITY_RATIO           float64 `json:"complexity_ratio"`
-	PERCENTILE_INTENSITY_RATIO float64 `json:"percentile_intensity_ratio"`
-	INTEREST                   float64 `json:"interest"`
-}
-
-type STAT_SSVAR struct {
-	TOTAL       int     `json:"total"`
-	N_BIN       int     `json:"n_bin"`
-	BIN_I       int     `json:"bin_i"`
-	BIN_N       int     `json:"bin_n"`
-	VAR_MIN     float64 `json:"var_min"`
-	VAR_MAX     float64 `json:"var_max"`
-	VAR_MEAN    float64 `json:"var_mean"`
-	FBAR        float64 `json:"fbar"`
-	OBAR        float64 `json:"obar"`
-	FOBAR       float64 `json:"fobar"`
-	FFBAR       float64 `json:"ffbar"`
-	OOBAR       float64 `json:"oobar"`
-	FBAR_NCL    float64 `json:"fbar_ncl"`
-	FBAR_NCU    float64 `json:"fbar_ncu"`
-	FSTDEV      float64 `json:"fstdev"`
-	FSTDEV_NCL  float64 `json:"fstdev_ncl"`
-	FSTDEV_NCU  float64 `json:"fstdev_ncu"`
-	OBAR_NCL    float64 `json:"obar_ncl"`
-	OBAR_NCU    float64 `json:"obar_ncu"`
-	OSTDEV      float64 `json:"ostdev"`
-	OSTDEV_NCL  float64 `json:"ostdev_ncl"`
-	OSTDEV_NCU  float64 `json:"ostdev_ncu"`
-	PR_CORR     float64 `json:"pr_corr"`
-	PR_CORR_NCL float64 `json:"pr_corr_ncl"`
-	PR_CORR_NCU float64 `json:"pr_corr_ncu"`
-	ME          float64 `json:"me"`
-	ME_NCL      float64 `json:"me_ncl"`
-	ME_NCU      float64 `json:"me_ncu"`
-	ESTDEV      float64 `json:"estdev"`
-	ESTDEV_NCL  float64 `json:"estdev_ncl"`
-	ESTDEV_NCU  float64 `json:"estdev_ncu"`
-	MBIAS       float64 `json:"mbias"`
-	MSE         float64 `json:"mse"`
-	BCMSE       float64 `json:"bcmse"`
-	RMSE        float64 `json:"rmse"`
-}
-
-type MTD_2DSINGLE struct {
-	OBJECT_ID      string  `json:"object_id"`
-	OBJECT_CAT     string  `json:"object_cat"`
-	TIME_INDEX     int     `json:"time_index"`
-	AREA           int     `json:"area"`
-	CENTROID_X     float64 `json:"centroid_x"`
-	CENTROID_Y     float64 `json:"centroid_y"`
-	CENTROID_LAT   float64 `json:"centroid_lat"`
-	CENTROID_LON   float64 `json:"centroid_lon"`
-	AXIS_ANG       float64 `json:"axis_ang"`
-	INTENSITY_10   float64 `json:"intensity_10"`
-	INTENSITY_25   float64 `json:"intensity_25"`
-	INTENSITY_50   float64 `json:"intensity_50"`
-	INTENSITY_75   float64 `json:"intensity_75"`
-	INTENSITY_90   float64 `json:"intensity_90"`
-	INTENSITY_USER float64 `json:"intensity_user"`
+type STAT_CTC struct {
+	TOTAL    int     `json:"total"`
+	FY_OY    float64 `json:"fy_oy"`
+	FY_ON    float64 `json:"fy_on"`
+	FN_OY    float64 `json:"fn_oy"`
+	FN_ON    float64 `json:"fn_on"`
+	EC_VALUE float64 `json:"ec_value"`
 }
 
 // fillStructure functions
-func (s *STAT_SEEPS_MPR) fill_STAT_SEEPS_MPR(fields []string) {
+func (s *TCST_TCMPR) fill_TCST_TCMPR(fields []string) {
 	dataLen := len(fields) - 1
 	i := -1
 	i++
 	if i <= dataLen {
-		s.OBS_SID = fields[0]
+		s.TOTAL, _ = strconv.Atoi(fields[0])
 	}
 	i++
 	if i <= dataLen {
-		s.OBS_LAT, _ = strconv.ParseFloat(fields[1], 64)
+		s.INDEX, _ = strconv.Atoi(fields[1])
 	}
 	i++
 	if i <= dataLen {
-		s.OBS_LON, _ = strconv.ParseFloat(fields[2], 64)
+		s.LEVEL = fields[2]
 	}
 	i++
 	if i <= dataLen {
-		s.FCST, _ = strconv.ParseFloat(fields[3], 64)
+		s.WATCH_WARN = fields[3]
 	}
 	i++
 	if i <= dataLen {
-		s.OBS, _ = strconv.ParseFloat(fields[4], 64)
+		s.INITIALS = fields[4]
 	}
 	i++
 	if i <= dataLen {
-		s.OBS_QC = fields[5]
+		s.ALAT, _ = strconv.ParseFloat(fields[5], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.FCST_CAT, _ = strconv.Atoi(fields[6])
+		s.ALON, _ = strconv.ParseFloat(fields[6], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.OBS_CAT, _ = strconv.Atoi(fields[7])
+		s.BLAT, _ = strconv.ParseFloat(fields[7], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.P1, _ = strconv.ParseFloat(fields[8], 64)
+		s.BLON, _ = strconv.ParseFloat(fields[8], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.P2, _ = strconv.ParseFloat(fields[9], 64)
+		s.TK_ERR, _ = strconv.ParseFloat(fields[9], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.T1, _ = strconv.ParseFloat(fields[10], 64)
+		s.X_ERR, _ = strconv.ParseFloat(fields[10], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.T2, _ = strconv.ParseFloat(fields[11], 64)
+		s.Y_ERR, _ = strconv.ParseFloat(fields[11], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.SEEPS, _ = strconv.ParseFloat(fields[12], 64)
+		s.ALTK_ERR, _ = strconv.ParseFloat(fields[12], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CRTK_ERR, _ = strconv.ParseFloat(fields[13], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ADLAND, _ = strconv.ParseFloat(fields[14], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BDLAND, _ = strconv.ParseFloat(fields[15], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.AMSLP, _ = strconv.ParseFloat(fields[16], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BMSLP, _ = strconv.ParseFloat(fields[17], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.AMAX_WIND, _ = strconv.ParseFloat(fields[18], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BMAX_WIND, _ = strconv.ParseFloat(fields[19], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.AAL_WIND_34, _ = strconv.ParseFloat(fields[20], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BAL_WIND_34, _ = strconv.ParseFloat(fields[21], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ANE_WIND_34, _ = strconv.ParseFloat(fields[22], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BNE_WIND_34, _ = strconv.ParseFloat(fields[23], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ASE_WIND_34, _ = strconv.ParseFloat(fields[24], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BSE_WIND_34, _ = strconv.ParseFloat(fields[25], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ASW_WIND_34, _ = strconv.ParseFloat(fields[26], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BSW_WIND_34, _ = strconv.ParseFloat(fields[27], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ANW_WIND_34, _ = strconv.ParseFloat(fields[28], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BNW_WIND_34, _ = strconv.ParseFloat(fields[29], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.AAL_WIND_50, _ = strconv.ParseFloat(fields[30], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BAL_WIND_50, _ = strconv.ParseFloat(fields[31], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ANE_WIND_50, _ = strconv.ParseFloat(fields[32], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BNE_WIND_50, _ = strconv.ParseFloat(fields[33], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ASE_WIND_50, _ = strconv.ParseFloat(fields[34], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BSE_WIND_50, _ = strconv.ParseFloat(fields[35], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ASW_WIND_50, _ = strconv.ParseFloat(fields[36], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BSW_WIND_50, _ = strconv.ParseFloat(fields[37], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ANW_WIND_50, _ = strconv.ParseFloat(fields[38], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BNW_WIND_50, _ = strconv.ParseFloat(fields[39], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.AAL_WIND_64, _ = strconv.ParseFloat(fields[40], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BAL_WIND_64, _ = strconv.ParseFloat(fields[41], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ANE_WIND_64, _ = strconv.ParseFloat(fields[42], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BNE_WIND_64, _ = strconv.ParseFloat(fields[43], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ASE_WIND_64, _ = strconv.ParseFloat(fields[44], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BSE_WIND_64, _ = strconv.ParseFloat(fields[45], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ASW_WIND_64, _ = strconv.ParseFloat(fields[46], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BSW_WIND_64, _ = strconv.ParseFloat(fields[47], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ANW_WIND_64, _ = strconv.ParseFloat(fields[48], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BNW_WIND_64, _ = strconv.ParseFloat(fields[49], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ARADP = fields[50]
+	}
+	i++
+	if i <= dataLen {
+		s.BRADP, _ = strconv.ParseFloat(fields[51], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ARRP, _ = strconv.Atoi(fields[52])
+	}
+	i++
+	if i <= dataLen {
+		s.BRRP, _ = strconv.ParseFloat(fields[53], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.AMRD, _ = strconv.Atoi(fields[54])
+	}
+	i++
+	if i <= dataLen {
+		s.BMRD, _ = strconv.ParseFloat(fields[55], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.AGUSTS, _ = strconv.Atoi(fields[56])
+	}
+	i++
+	if i <= dataLen {
+		s.BGUSTS, _ = strconv.ParseFloat(fields[57], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.AEYE, _ = strconv.Atoi(fields[58])
+	}
+	i++
+	if i <= dataLen {
+		s.BEYE, _ = strconv.ParseFloat(fields[59], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ADIR, _ = strconv.Atoi(fields[60])
+	}
+	i++
+	if i <= dataLen {
+		s.BDIR, _ = strconv.ParseFloat(fields[61], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ASPEED, _ = strconv.Atoi(fields[62])
+	}
+	i++
+	if i <= dataLen {
+		s.BSPEED, _ = strconv.ParseFloat(fields[63], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ADEPTH, _ = strconv.Atoi(fields[64])
+	}
+	i++
+	if i <= dataLen {
+		s.BDEPTH, _ = strconv.ParseFloat(fields[65], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.NUM_MEMBERS, _ = strconv.ParseFloat(fields[66], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.TRACK_SPREAD, _ = strconv.ParseFloat(fields[67], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.TRACK_STDEV, _ = strconv.ParseFloat(fields[68], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.MSLP_STDEV, _ = strconv.ParseFloat(fields[69], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.MAX_WIND_STDEV, _ = strconv.ParseFloat(fields[70], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INIT, _ = strconv.Atoi(fields[71])
+	}
+}
+
+func (s *STAT_FHO) fill_STAT_FHO(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen {
+		s.F_RATE, _ = strconv.ParseFloat(fields[1], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.H_RATE, _ = strconv.ParseFloat(fields[2], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.O_RATE, _ = strconv.ParseFloat(fields[3], 64)
 	}
 }
 
@@ -4448,261 +4699,230 @@ func (s *STAT_ORANK) fill_STAT_ORANK(fields []string) {
 	}
 }
 
-func (s *STAT_PRC) fill_STAT_PRC(fields []string) {
+func (s *STAT_PHIST) fill_STAT_PHIST(fields []string) {
 	dataLen := len(fields) - 1
 	i := -1
 	i++
 	if i <= dataLen {
 		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen {
+		s.BIN_SIZE, _ = strconv.Atoi(fields[1])
 	}
 	i++
 	if i <= dataLen { // the first field of the repeating fields is the TOTAL, the second field is the 1st dimenSion of the 1st sequence (there might be only one sequence)
 		var value interface{}
-		count, err := strconv.Atoi(fields[1])
+		count, err := strconv.Atoi(fields[2])
 		if err != nil {
 			count = 0
 		}
-		keyPrefixes := []string{"THRESH_", "PODY_", "POFD_"}
-		s.THRESH = make(map[string]interface{})
+		keyPrefixes := []string{"BIN_"}
+		s.BIN = make(map[string]interface{})
 		for group := 1; group <= count; group++ {
-			for index := 2; index <= len(keyPrefixes); index++ {
+			for index := 3; index <= len(keyPrefixes); index++ {
 				key := fmt.Sprintf("%s_%d", keyPrefixes[index-1], index)
 				if index > len(fields) { // sometimes the data line is truncated - we will set expected data to "NA"
-					value = "NA"
-				} else {
-					value, err = strconv.ParseFloat(fields[index], 64)
-					if err != nil { // sometimes there can be these NA values in the data, which will be left out of json
-						value = "NA"
-					}
-				}
-				s.THRESH[key] = value
-			}
-		}
-	}
-}
-
-func (s *STAT_ECNT) fill_STAT_ECNT(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen {
-		s.N_ENS, _ = strconv.Atoi(fields[1])
-	}
-	i++
-	if i <= dataLen {
-		s.CRPS, _ = strconv.ParseFloat(fields[2], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CRPSS, _ = strconv.ParseFloat(fields[3], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.IGN, _ = strconv.ParseFloat(fields[4], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ME, _ = strconv.ParseFloat(fields[5], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.RMSE, _ = strconv.ParseFloat(fields[6], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SPREAD, _ = strconv.ParseFloat(fields[7], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ME_OERR, _ = strconv.ParseFloat(fields[8], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.RMSE_OERR, _ = strconv.ParseFloat(fields[9], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SPREAD_OERR, _ = strconv.ParseFloat(fields[10], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SPREAD_PLUS_OERR, _ = strconv.ParseFloat(fields[11], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CRPSCL, _ = strconv.ParseFloat(fields[12], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CRPS_EMP, _ = strconv.ParseFloat(fields[13], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CRPSCL_EMP, _ = strconv.ParseFloat(fields[14], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CRPSS_EMP, _ = strconv.ParseFloat(fields[15], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CRPS_EMP_FAIR, _ = strconv.ParseFloat(fields[16], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SPREAD_MD, _ = strconv.ParseFloat(fields[17], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.MAE, _ = strconv.ParseFloat(fields[18], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.MAE_OERR, _ = strconv.ParseFloat(fields[19], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BIAS_RATIO, _ = strconv.ParseFloat(fields[20], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.N_GE_OBS, _ = strconv.Atoi(fields[21])
-	}
-	i++
-	if i <= dataLen {
-		s.ME_GE_OBS, _ = strconv.ParseFloat(fields[22], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.N_LT_OBS, _ = strconv.Atoi(fields[23])
-	}
-	i++
-	if i <= dataLen {
-		s.ME_LT_OBS, _ = strconv.ParseFloat(fields[24], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.IGN_CONV_OERR, _ = strconv.ParseFloat(fields[25], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.IGN_CORR_OERR, _ = strconv.ParseFloat(fields[26], 64)
-	}
-}
-
-func (s *STAT_RPS) fill_STAT_RPS(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen {
-		s.N_PROB, _ = strconv.Atoi(fields[1])
-	}
-	i++
-	if i <= dataLen {
-		s.RPS_REL, _ = strconv.ParseFloat(fields[2], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.RPS_RES, _ = strconv.ParseFloat(fields[3], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.RPS_UNC, _ = strconv.ParseFloat(fields[4], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.RPS, _ = strconv.ParseFloat(fields[5], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.RPSS, _ = strconv.ParseFloat(fields[6], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.RPSS_SMPL, _ = strconv.ParseFloat(fields[7], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.RPS_COMP, _ = strconv.ParseFloat(fields[8], 64)
-	}
-}
-
-func (s *STAT_RELP) fill_STAT_RELP(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen { // the first field of the repeating fields is the TOTAL, the second field is the 1st dimenSion of the 1st sequence (there might be only one sequence)
-		var value interface{}
-		count, err := strconv.Atoi(fields[1])
-		if err != nil {
-			count = 0
-		}
-		keyPrefixes := []string{"RELP_"}
-		s.ENS = make(map[string]interface{})
-		for group := 1; group <= count; group++ {
-			for index := 2; index <= len(keyPrefixes); index++ {
-				key := fmt.Sprintf("%s_%d", keyPrefixes[index-1], index)
-				if index > len(fields) { // sometimes the data line is truncated - we will set expected data to "NA"
-					value = "NA"
-				} else {
-					value, err = strconv.ParseFloat(fields[index], 64)
-					if err != nil { // sometimes there can be these NA values in the data, which will be left out of json
-						value = "NA"
-					}
-				}
-				s.ENS[key] = value
-			}
-		}
-	}
-}
-
-func (s *STAT_MCTC) fill_STAT_MCTC(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen { // these values seem to always be ints (or "NA")
-		var value interface{}
-		count, err := strconv.Atoi(fields[1])
-		if err != nil {
-			count = 0
-		}
-		s.CAT = make(map[string]interface{})
-		for i1 := 1; i1 <= count; i1++ {
-			for i2 := 1; i2 <= count; i2++ {
-				// generate the particular key for the map i.e. F1_O1, F1_O2, F1_O3, F1_O4, F2_O1, F2_O2, F2_O3, F2_O4, etc.
-				key := fmt.Sprintf("F%d_O%d", i1, i2)
-				index := (i1-1)*count + i2
-				if index >= len(fields) {
 					value = "NA"
 				} else {
 					value, err = strconv.Atoi(fields[index])
+					if err != nil { // sometimes there can be these NA values in the data, which will be left out of json
+						value = "NA"
+					}
 				}
-				if err != nil {
-					value = "NA"
-				}
-				s.CAT[key] = value
+				s.BIN[key] = value
 			}
 		}
 	}
+}
+
+func (s *STAT_NBRCNT) fill_STAT_NBRCNT(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
 	i++
 	if i <= dataLen {
-		s.EC_VALUE, _ = strconv.ParseFloat(fields[3], 64)
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen {
+		s.FBS, _ = strconv.ParseFloat(fields[1], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FBS_BCL, _ = strconv.ParseFloat(fields[2], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FBS_BCU, _ = strconv.ParseFloat(fields[3], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FSS, _ = strconv.ParseFloat(fields[4], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FSS_BCL, _ = strconv.ParseFloat(fields[5], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FSS_BCU, _ = strconv.ParseFloat(fields[6], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.AFSS, _ = strconv.ParseFloat(fields[7], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.AFSS_BCL, _ = strconv.ParseFloat(fields[8], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.AFSS_BCU, _ = strconv.ParseFloat(fields[9], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.UFSS, _ = strconv.ParseFloat(fields[10], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.UFSS_BCL, _ = strconv.ParseFloat(fields[11], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.UFSS_BCU, _ = strconv.ParseFloat(fields[12], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.F_RATE, _ = strconv.ParseFloat(fields[13], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.F_RATE_BCL, _ = strconv.ParseFloat(fields[14], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.F_RATE_BCU, _ = strconv.ParseFloat(fields[15], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.O_RATE, _ = strconv.ParseFloat(fields[16], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.O_RATE_BCL, _ = strconv.ParseFloat(fields[17], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.O_RATE_BCU, _ = strconv.ParseFloat(fields[18], 64)
+	}
+}
+
+func (s *MODE_CTS) fill_MODE_CTS(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.FIELD = fields[0]
+	}
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[1])
+	}
+	i++
+	if i <= dataLen {
+		s.FY_OY, _ = strconv.ParseFloat(fields[2], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FY_ON, _ = strconv.ParseFloat(fields[3], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FN_OY, _ = strconv.ParseFloat(fields[4], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FN_ON, _ = strconv.ParseFloat(fields[5], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BASER, _ = strconv.ParseFloat(fields[6], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FMEAN, _ = strconv.ParseFloat(fields[7], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ACC, _ = strconv.ParseFloat(fields[8], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FBIAS, _ = strconv.ParseFloat(fields[9], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PODY, _ = strconv.ParseFloat(fields[10], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PODN, _ = strconv.ParseFloat(fields[11], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.POFD, _ = strconv.ParseFloat(fields[12], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FAR, _ = strconv.ParseFloat(fields[13], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CSI, _ = strconv.ParseFloat(fields[14], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.GSS, _ = strconv.ParseFloat(fields[15], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HK, _ = strconv.ParseFloat(fields[16], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HSS, _ = strconv.ParseFloat(fields[17], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ODDS, _ = strconv.ParseFloat(fields[18], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.LODDS, _ = strconv.ParseFloat(fields[19], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ORSS, _ = strconv.ParseFloat(fields[20], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.EDS, _ = strconv.ParseFloat(fields[21], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SEDS, _ = strconv.ParseFloat(fields[22], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.EDI, _ = strconv.ParseFloat(fields[23], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SEDI, _ = strconv.ParseFloat(fields[24], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BAGSS, _ = strconv.ParseFloat(fields[25], 64)
 	}
 }
 
@@ -4771,7 +4991,100 @@ func (s *STAT_MPR) fill_STAT_MPR(fields []string) {
 	}
 }
 
-func (s *STAT_PHIST) fill_STAT_PHIST(fields []string) {
+func (s *STAT_PSTD) fill_STAT_PSTD(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen { // the first field of the repeating fields is the TOTAL, the second field is the 1st dimenSion of the 1st sequence (there might be only one sequence)
+		var value interface{}
+		count, err := strconv.Atoi(fields[1])
+		if err != nil {
+			count = 0
+		}
+		keyPrefixes := []string{"THRESH_"}
+		s.THRESH = make(map[string]interface{})
+		for group := 1; group <= count; group++ {
+			for index := 2; index <= len(keyPrefixes); index++ {
+				key := fmt.Sprintf("%s_%d", keyPrefixes[index-1], index)
+				if index > len(fields) { // sometimes the data line is truncated - we will set expected data to "NA"
+					value = "NA"
+				} else {
+					value, err = strconv.ParseFloat(fields[index], 64)
+					if err != nil { // sometimes there can be these NA values in the data, which will be left out of json
+						value = "NA"
+					}
+				}
+				s.THRESH[key] = value
+			}
+		}
+	}
+	i++
+	if i <= dataLen {
+		s.BASER_NCL, _ = strconv.ParseFloat(fields[3], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BASER_NCU, _ = strconv.ParseFloat(fields[4], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.RELIABILITY, _ = strconv.ParseFloat(fields[5], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.RESOLUTION, _ = strconv.ParseFloat(fields[6], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.UNCERTAINTY, _ = strconv.ParseFloat(fields[7], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ROC_AUC, _ = strconv.ParseFloat(fields[8], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BRIER, _ = strconv.ParseFloat(fields[9], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BRIER_NCL, _ = strconv.ParseFloat(fields[10], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BRIER_NCU, _ = strconv.ParseFloat(fields[11], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BRIERCL, _ = strconv.ParseFloat(fields[12], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BRIERCL_NCL, _ = strconv.ParseFloat(fields[13], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BRIERCL_NCU, _ = strconv.ParseFloat(fields[14], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BSS, _ = strconv.ParseFloat(fields[15], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BSS_SMPL, _ = strconv.ParseFloat(fields[16], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.THRESH_I, _ = strconv.Atoi(fields[17])
+	}
+}
+
+func (s *STAT_ECLV) fill_STAT_ECLV(fields []string) {
 	dataLen := len(fields) - 1
 	i := -1
 	i++
@@ -4780,19 +5093,56 @@ func (s *STAT_PHIST) fill_STAT_PHIST(fields []string) {
 	}
 	i++
 	if i <= dataLen {
-		s.BIN_SIZE, _ = strconv.Atoi(fields[1])
+		s.BASER, _ = strconv.ParseFloat(fields[1], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.VALUE_BASER, _ = strconv.Atoi(fields[2])
 	}
 	i++
 	if i <= dataLen { // the first field of the repeating fields is the TOTAL, the second field is the 1st dimenSion of the 1st sequence (there might be only one sequence)
 		var value interface{}
-		count, err := strconv.Atoi(fields[2])
+		count, err := strconv.Atoi(fields[3])
 		if err != nil {
 			count = 0
 		}
-		keyPrefixes := []string{"BIN_"}
-		s.BIN = make(map[string]interface{})
+		keyPrefixes := []string{"CL_", "VALUE_"}
+		s.PTS = make(map[string]interface{})
 		for group := 1; group <= count; group++ {
-			for index := 3; index <= len(keyPrefixes); index++ {
+			for index := 4; index <= len(keyPrefixes); index++ {
+				key := fmt.Sprintf("%s_%d", keyPrefixes[index-1], index)
+				if index > len(fields) { // sometimes the data line is truncated - we will set expected data to "NA"
+					value = "NA"
+				} else {
+					value, err = strconv.ParseFloat(fields[index], 64)
+					if err != nil { // sometimes there can be these NA values in the data, which will be left out of json
+						value = "NA"
+					}
+				}
+				s.PTS[key] = value
+			}
+		}
+	}
+}
+
+func (s *STAT_RHIST) fill_STAT_RHIST(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen { // the first field of the repeating fields is the TOTAL, the second field is the 1st dimenSion of the 1st sequence (there might be only one sequence)
+		var value interface{}
+		count, err := strconv.Atoi(fields[1])
+		if err != nil {
+			count = 0
+		}
+		keyPrefixes := []string{"RANK_"}
+		s.RANK = make(map[string]interface{})
+		for group := 1; group <= count; group++ {
+			for index := 2; index <= len(keyPrefixes); index++ {
 				key := fmt.Sprintf("%s_%d", keyPrefixes[index-1], index)
 				if index > len(fields) { // sometimes the data line is truncated - we will set expected data to "NA"
 					value = "NA"
@@ -4802,13 +5152,13 @@ func (s *STAT_PHIST) fill_STAT_PHIST(fields []string) {
 						value = "NA"
 					}
 				}
-				s.BIN[key] = value
+				s.RANK[key] = value
 			}
 		}
 	}
 }
 
-func (s *STAT_SAL1L2) fill_STAT_SAL1L2(fields []string) {
+func (s *STAT_SSVAR) fill_STAT_SSVAR(fields []string) {
 	dataLen := len(fields) - 1
 	i := -1
 	i++
@@ -4817,27 +5167,139 @@ func (s *STAT_SAL1L2) fill_STAT_SAL1L2(fields []string) {
 	}
 	i++
 	if i <= dataLen {
-		s.FABAR, _ = strconv.ParseFloat(fields[1], 64)
+		s.N_BIN, _ = strconv.Atoi(fields[1])
 	}
 	i++
 	if i <= dataLen {
-		s.OABAR, _ = strconv.ParseFloat(fields[2], 64)
+		s.BIN_I, _ = strconv.Atoi(fields[2])
 	}
 	i++
 	if i <= dataLen {
-		s.FOABAR, _ = strconv.ParseFloat(fields[3], 64)
+		s.BIN_N, _ = strconv.Atoi(fields[3])
 	}
 	i++
 	if i <= dataLen {
-		s.FFABAR, _ = strconv.ParseFloat(fields[4], 64)
+		s.VAR_MIN, _ = strconv.ParseFloat(fields[4], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.OOABAR, _ = strconv.ParseFloat(fields[5], 64)
+		s.VAR_MAX, _ = strconv.ParseFloat(fields[5], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.MAE, _ = strconv.ParseFloat(fields[6], 64)
+		s.VAR_MEAN, _ = strconv.ParseFloat(fields[6], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FBAR, _ = strconv.ParseFloat(fields[7], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OBAR, _ = strconv.ParseFloat(fields[8], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FOBAR, _ = strconv.ParseFloat(fields[9], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FFBAR, _ = strconv.ParseFloat(fields[10], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OOBAR, _ = strconv.ParseFloat(fields[11], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FBAR_NCL, _ = strconv.ParseFloat(fields[12], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FBAR_NCU, _ = strconv.ParseFloat(fields[13], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FSTDEV, _ = strconv.ParseFloat(fields[14], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FSTDEV_NCL, _ = strconv.ParseFloat(fields[15], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FSTDEV_NCU, _ = strconv.ParseFloat(fields[16], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OBAR_NCL, _ = strconv.ParseFloat(fields[17], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OBAR_NCU, _ = strconv.ParseFloat(fields[18], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OSTDEV, _ = strconv.ParseFloat(fields[19], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OSTDEV_NCL, _ = strconv.ParseFloat(fields[20], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OSTDEV_NCU, _ = strconv.ParseFloat(fields[21], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PR_CORR, _ = strconv.ParseFloat(fields[22], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PR_CORR_NCL, _ = strconv.ParseFloat(fields[23], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PR_CORR_NCU, _ = strconv.ParseFloat(fields[24], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ME, _ = strconv.ParseFloat(fields[25], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ME_NCL, _ = strconv.ParseFloat(fields[26], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ME_NCU, _ = strconv.ParseFloat(fields[27], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ESTDEV, _ = strconv.ParseFloat(fields[28], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ESTDEV_NCL, _ = strconv.ParseFloat(fields[29], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ESTDEV_NCU, _ = strconv.ParseFloat(fields[30], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.MBIAS, _ = strconv.ParseFloat(fields[31], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.MSE, _ = strconv.ParseFloat(fields[32], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BCMSE, _ = strconv.ParseFloat(fields[33], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.RMSE, _ = strconv.ParseFloat(fields[34], 64)
 	}
 }
 
@@ -5150,155 +5612,6 @@ func (s *STAT_VCNT) fill_STAT_VCNT(fields []string) {
 	}
 }
 
-func (s *MODE_OBJ) fill_MODE_OBJ(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.OBJECT_ID = fields[0]
-	}
-	i++
-	if i <= dataLen {
-		s.OBJECT_CAT = fields[1]
-	}
-	i++
-	if i <= dataLen {
-		s.CENTROID_X, _ = strconv.ParseFloat(fields[2], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CENTROID_Y, _ = strconv.ParseFloat(fields[3], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CENTROID_LAT, _ = strconv.ParseFloat(fields[4], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CENTROID_LON, _ = strconv.ParseFloat(fields[5], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AXIS_ANG, _ = strconv.ParseFloat(fields[6], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.LENGTH, _ = strconv.ParseFloat(fields[7], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.WIDTH, _ = strconv.ParseFloat(fields[8], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AREA, _ = strconv.Atoi(fields[9])
-	}
-	i++
-	if i <= dataLen {
-		s.AREA_THRESH, _ = strconv.Atoi(fields[10])
-	}
-	i++
-	if i <= dataLen {
-		s.CURVATURE, _ = strconv.ParseFloat(fields[11], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CURVATURE_X, _ = strconv.ParseFloat(fields[12], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CURVATURE_Y, _ = strconv.ParseFloat(fields[13], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.COMPLEXITY, _ = strconv.ParseFloat(fields[14], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTENSITY_10, _ = strconv.ParseFloat(fields[15], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTENSITY_25, _ = strconv.ParseFloat(fields[16], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTENSITY_50, _ = strconv.ParseFloat(fields[17], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTENSITY_75, _ = strconv.ParseFloat(fields[18], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTENSITY_90, _ = strconv.ParseFloat(fields[19], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTENSITY_USER, _ = strconv.ParseFloat(fields[20], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTENSITY_SUM, _ = strconv.ParseFloat(fields[21], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CENTROID_DIST, _ = strconv.ParseFloat(fields[22], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BOUNDARY_DIST, _ = strconv.ParseFloat(fields[23], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CONVEX_HULL_DIST, _ = strconv.ParseFloat(fields[24], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ANGLE_DIFF, _ = strconv.ParseFloat(fields[25], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ASPECT_DIFF, _ = strconv.ParseFloat(fields[26], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AREA_RATIO, _ = strconv.ParseFloat(fields[27], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTERSECTION_AREA, _ = strconv.ParseFloat(fields[28], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.UNION_AREA, _ = strconv.ParseFloat(fields[29], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SYMMETRIC_DIFF, _ = strconv.ParseFloat(fields[30], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTERSECTION_OVER_AREA, _ = strconv.ParseFloat(fields[31], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CURVATURE_RATIO, _ = strconv.ParseFloat(fields[32], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.COMPLEXITY_RATIO, _ = strconv.ParseFloat(fields[33], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.PERCENTILE_INTENSITY_RATIO, _ = strconv.ParseFloat(fields[34], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTEREST, _ = strconv.ParseFloat(fields[35], 64)
-	}
-}
-
 func (s *MTD_3DPAIR) fill_MTD_3DPAIR(fields []string) {
 	dataLen := len(fields) - 1
 	i := -1
@@ -5353,1525 +5666,6 @@ func (s *MTD_3DPAIR) fill_MTD_3DPAIR(fields []string) {
 	i++
 	if i <= dataLen {
 		s.INTEREST, _ = strconv.ParseFloat(fields[12], 64)
-	}
-}
-
-func (s *TCST_TCMPR) fill_TCST_TCMPR(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen {
-		s.INDEX, _ = strconv.Atoi(fields[1])
-	}
-	i++
-	if i <= dataLen {
-		s.LEVEL = fields[2]
-	}
-	i++
-	if i <= dataLen {
-		s.WATCH_WARN = fields[3]
-	}
-	i++
-	if i <= dataLen {
-		s.INITIALS = fields[4]
-	}
-	i++
-	if i <= dataLen {
-		s.ALAT, _ = strconv.ParseFloat(fields[5], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ALON, _ = strconv.ParseFloat(fields[6], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BLAT, _ = strconv.ParseFloat(fields[7], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BLON, _ = strconv.ParseFloat(fields[8], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.TK_ERR, _ = strconv.ParseFloat(fields[9], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.X_ERR, _ = strconv.ParseFloat(fields[10], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.Y_ERR, _ = strconv.ParseFloat(fields[11], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ALTK_ERR, _ = strconv.ParseFloat(fields[12], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CRTK_ERR, _ = strconv.ParseFloat(fields[13], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ADLAND, _ = strconv.ParseFloat(fields[14], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BDLAND, _ = strconv.ParseFloat(fields[15], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AMSLP, _ = strconv.ParseFloat(fields[16], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BMSLP, _ = strconv.ParseFloat(fields[17], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AMAX_WIND, _ = strconv.ParseFloat(fields[18], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BMAX_WIND, _ = strconv.ParseFloat(fields[19], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AAL_WIND_34, _ = strconv.ParseFloat(fields[20], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BAL_WIND_34, _ = strconv.ParseFloat(fields[21], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ANE_WIND_34, _ = strconv.ParseFloat(fields[22], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BNE_WIND_34, _ = strconv.ParseFloat(fields[23], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ASE_WIND_34, _ = strconv.ParseFloat(fields[24], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BSE_WIND_34, _ = strconv.ParseFloat(fields[25], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ASW_WIND_34, _ = strconv.ParseFloat(fields[26], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BSW_WIND_34, _ = strconv.ParseFloat(fields[27], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ANW_WIND_34, _ = strconv.ParseFloat(fields[28], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BNW_WIND_34, _ = strconv.ParseFloat(fields[29], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AAL_WIND_50, _ = strconv.ParseFloat(fields[30], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BAL_WIND_50, _ = strconv.ParseFloat(fields[31], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ANE_WIND_50, _ = strconv.ParseFloat(fields[32], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BNE_WIND_50, _ = strconv.ParseFloat(fields[33], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ASE_WIND_50, _ = strconv.ParseFloat(fields[34], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BSE_WIND_50, _ = strconv.ParseFloat(fields[35], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ASW_WIND_50, _ = strconv.ParseFloat(fields[36], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BSW_WIND_50, _ = strconv.ParseFloat(fields[37], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ANW_WIND_50, _ = strconv.ParseFloat(fields[38], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BNW_WIND_50, _ = strconv.ParseFloat(fields[39], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AAL_WIND_64, _ = strconv.ParseFloat(fields[40], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BAL_WIND_64, _ = strconv.ParseFloat(fields[41], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ANE_WIND_64, _ = strconv.ParseFloat(fields[42], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BNE_WIND_64, _ = strconv.ParseFloat(fields[43], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ASE_WIND_64, _ = strconv.ParseFloat(fields[44], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BSE_WIND_64, _ = strconv.ParseFloat(fields[45], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ASW_WIND_64, _ = strconv.ParseFloat(fields[46], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BSW_WIND_64, _ = strconv.ParseFloat(fields[47], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ANW_WIND_64, _ = strconv.ParseFloat(fields[48], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BNW_WIND_64, _ = strconv.ParseFloat(fields[49], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ARADP = fields[50]
-	}
-	i++
-	if i <= dataLen {
-		s.BRADP, _ = strconv.ParseFloat(fields[51], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ARRP, _ = strconv.Atoi(fields[52])
-	}
-	i++
-	if i <= dataLen {
-		s.BRRP, _ = strconv.ParseFloat(fields[53], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AMRD, _ = strconv.Atoi(fields[54])
-	}
-	i++
-	if i <= dataLen {
-		s.BMRD, _ = strconv.ParseFloat(fields[55], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AGUSTS, _ = strconv.Atoi(fields[56])
-	}
-	i++
-	if i <= dataLen {
-		s.BGUSTS, _ = strconv.ParseFloat(fields[57], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AEYE, _ = strconv.Atoi(fields[58])
-	}
-	i++
-	if i <= dataLen {
-		s.BEYE, _ = strconv.ParseFloat(fields[59], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ADIR, _ = strconv.Atoi(fields[60])
-	}
-	i++
-	if i <= dataLen {
-		s.BDIR, _ = strconv.ParseFloat(fields[61], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ASPEED, _ = strconv.Atoi(fields[62])
-	}
-	i++
-	if i <= dataLen {
-		s.BSPEED, _ = strconv.ParseFloat(fields[63], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ADEPTH, _ = strconv.Atoi(fields[64])
-	}
-	i++
-	if i <= dataLen {
-		s.BDEPTH, _ = strconv.ParseFloat(fields[65], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.NUM_MEMBERS, _ = strconv.ParseFloat(fields[66], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.TRACK_SPREAD, _ = strconv.ParseFloat(fields[67], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.TRACK_STDEV, _ = strconv.ParseFloat(fields[68], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.MSLP_STDEV, _ = strconv.ParseFloat(fields[69], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.MAX_WIND_STDEV, _ = strconv.ParseFloat(fields[70], 64)
-	}
-}
-
-func (s *STAT_CTS) fill_STAT_CTS(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen {
-		s.BASER, _ = strconv.ParseFloat(fields[1], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BASER_NCL, _ = strconv.ParseFloat(fields[2], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BASER_NCU, _ = strconv.ParseFloat(fields[3], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BASER_BCL, _ = strconv.ParseFloat(fields[4], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BASER_BCU, _ = strconv.ParseFloat(fields[5], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FMEAN, _ = strconv.ParseFloat(fields[6], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FMEAN_NCL, _ = strconv.ParseFloat(fields[7], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FMEAN_NCU, _ = strconv.ParseFloat(fields[8], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FMEAN_BCL, _ = strconv.ParseFloat(fields[9], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FMEAN_BCU, _ = strconv.ParseFloat(fields[10], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ACC, _ = strconv.ParseFloat(fields[11], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ACC_NCL, _ = strconv.ParseFloat(fields[12], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ACC_NCU, _ = strconv.ParseFloat(fields[13], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ACC_BCL, _ = strconv.ParseFloat(fields[14], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ACC_BCU, _ = strconv.ParseFloat(fields[15], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FBIAS, _ = strconv.ParseFloat(fields[16], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FBIAS_BCL, _ = strconv.ParseFloat(fields[17], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FBIAS_BCU, _ = strconv.ParseFloat(fields[18], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.PODY, _ = strconv.ParseFloat(fields[19], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.PODY_NCL, _ = strconv.ParseFloat(fields[20], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.PODY_NCU, _ = strconv.ParseFloat(fields[21], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.PODY_BCL, _ = strconv.ParseFloat(fields[22], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.PODY_BCU, _ = strconv.ParseFloat(fields[23], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.PODN, _ = strconv.ParseFloat(fields[24], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.PODN_NCL, _ = strconv.ParseFloat(fields[25], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.PODN_NCU, _ = strconv.ParseFloat(fields[26], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.PODN_BCL, _ = strconv.ParseFloat(fields[27], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.PODN_BCU, _ = strconv.ParseFloat(fields[28], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.POFD, _ = strconv.ParseFloat(fields[29], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.POFD_NCL, _ = strconv.ParseFloat(fields[30], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.POFD_NCU, _ = strconv.ParseFloat(fields[31], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.POFD_BCL, _ = strconv.ParseFloat(fields[32], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.POFD_BCU, _ = strconv.ParseFloat(fields[33], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FAR, _ = strconv.ParseFloat(fields[34], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FAR_NCL, _ = strconv.ParseFloat(fields[35], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FAR_NCU, _ = strconv.ParseFloat(fields[36], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FAR_BCL, _ = strconv.ParseFloat(fields[37], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FAR_BCU, _ = strconv.ParseFloat(fields[38], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CSI, _ = strconv.ParseFloat(fields[39], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CSI_NCL, _ = strconv.ParseFloat(fields[40], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CSI_NCU, _ = strconv.ParseFloat(fields[41], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CSI_BCL, _ = strconv.ParseFloat(fields[42], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CSI_BCU, _ = strconv.ParseFloat(fields[43], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.GSS, _ = strconv.ParseFloat(fields[44], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.GSS_BCL, _ = strconv.ParseFloat(fields[45], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.GSS_BCU, _ = strconv.ParseFloat(fields[46], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HK, _ = strconv.ParseFloat(fields[47], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HK_NCL, _ = strconv.ParseFloat(fields[48], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HK_NCU, _ = strconv.ParseFloat(fields[49], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HK_BCL, _ = strconv.ParseFloat(fields[50], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HK_BCU, _ = strconv.ParseFloat(fields[51], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HSS, _ = strconv.ParseFloat(fields[52], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HSS_BCL, _ = strconv.ParseFloat(fields[53], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HSS_BCU, _ = strconv.ParseFloat(fields[54], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ODDS, _ = strconv.ParseFloat(fields[55], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ODDS_NCL, _ = strconv.ParseFloat(fields[56], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ODDS_NCU, _ = strconv.ParseFloat(fields[57], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ODDS_BCL, _ = strconv.ParseFloat(fields[58], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ODDS_BCU, _ = strconv.ParseFloat(fields[59], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.LODDS, _ = strconv.ParseFloat(fields[60], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.LODDS_NCL, _ = strconv.ParseFloat(fields[61], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.LODDS_NCU, _ = strconv.ParseFloat(fields[62], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.LODDS_BCL, _ = strconv.ParseFloat(fields[63], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.LODDS_BCU, _ = strconv.ParseFloat(fields[64], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ORSS, _ = strconv.ParseFloat(fields[65], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ORSS_NCL, _ = strconv.ParseFloat(fields[66], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ORSS_NCU, _ = strconv.ParseFloat(fields[67], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ORSS_BCL, _ = strconv.ParseFloat(fields[68], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ORSS_BCU, _ = strconv.ParseFloat(fields[69], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.EDS, _ = strconv.ParseFloat(fields[70], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.EDS_NCL, _ = strconv.ParseFloat(fields[71], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.EDS_NCU, _ = strconv.ParseFloat(fields[72], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.EDS_BCL, _ = strconv.ParseFloat(fields[73], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.EDS_BCU, _ = strconv.ParseFloat(fields[74], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SEDS, _ = strconv.ParseFloat(fields[75], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SEDS_NCL, _ = strconv.ParseFloat(fields[76], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SEDS_NCU, _ = strconv.ParseFloat(fields[77], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SEDS_BCL, _ = strconv.ParseFloat(fields[78], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SEDS_BCU, _ = strconv.ParseFloat(fields[79], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.EDI, _ = strconv.ParseFloat(fields[80], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.EDI_NCL, _ = strconv.ParseFloat(fields[81], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.EDI_NCU, _ = strconv.ParseFloat(fields[82], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.EDI_BCL, _ = strconv.ParseFloat(fields[83], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.EDI_BCU, _ = strconv.ParseFloat(fields[84], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SEDI, _ = strconv.ParseFloat(fields[85], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SEDI_NCL, _ = strconv.ParseFloat(fields[86], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SEDI_NCU, _ = strconv.ParseFloat(fields[87], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SEDI_BCL, _ = strconv.ParseFloat(fields[88], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SEDI_BCU, _ = strconv.ParseFloat(fields[89], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BAGSS, _ = strconv.ParseFloat(fields[90], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BAGSS_BCL, _ = strconv.ParseFloat(fields[91], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BAGSS_BCU, _ = strconv.ParseFloat(fields[92], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HSS_EC, _ = strconv.ParseFloat(fields[93], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HSS_EC_BCL, _ = strconv.ParseFloat(fields[94], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HSS_EC_BCU, _ = strconv.ParseFloat(fields[95], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.EC_VALUE, _ = strconv.ParseFloat(fields[96], 64)
-	}
-}
-
-func (s *STAT_NBRCTC) fill_STAT_NBRCTC(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen {
-		s.FY_OY, _ = strconv.ParseFloat(fields[1], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FY_ON, _ = strconv.ParseFloat(fields[2], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FN_OY, _ = strconv.ParseFloat(fields[3], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FN_ON, _ = strconv.ParseFloat(fields[4], 64)
-	}
-}
-
-func (s *STAT_PCT) fill_STAT_PCT(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen { // the first field of the repeating fields is the TOTAL, the second field is the 1st dimenSion of the 1st sequence (there might be only one sequence)
-		var value interface{}
-		count, err := strconv.Atoi(fields[1])
-		if err != nil {
-			count = 0
-		}
-		keyPrefixes := []string{"THRESH_", "OY_", "ON_"}
-		s.THRESH = make(map[string]interface{})
-		for group := 1; group <= count; group++ {
-			for index := 2; index <= len(keyPrefixes); index++ {
-				key := fmt.Sprintf("%s_%d", keyPrefixes[index-1], index)
-				if index > len(fields) { // sometimes the data line is truncated - we will set expected data to "NA"
-					value = "NA"
-				} else {
-					value, err = strconv.ParseFloat(fields[index], 64)
-					if err != nil { // sometimes there can be these NA values in the data, which will be left out of json
-						value = "NA"
-					}
-				}
-				s.THRESH[key] = value
-			}
-		}
-	}
-}
-
-func (s *STAT_PSTD) fill_STAT_PSTD(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen { // the first field of the repeating fields is the TOTAL, the second field is the 1st dimenSion of the 1st sequence (there might be only one sequence)
-		var value interface{}
-		count, err := strconv.Atoi(fields[1])
-		if err != nil {
-			count = 0
-		}
-		keyPrefixes := []string{"THRESH_"}
-		s.THRESH = make(map[string]interface{})
-		for group := 1; group <= count; group++ {
-			for index := 2; index <= len(keyPrefixes); index++ {
-				key := fmt.Sprintf("%s_%d", keyPrefixes[index-1], index)
-				if index > len(fields) { // sometimes the data line is truncated - we will set expected data to "NA"
-					value = "NA"
-				} else {
-					value, err = strconv.ParseFloat(fields[index], 64)
-					if err != nil { // sometimes there can be these NA values in the data, which will be left out of json
-						value = "NA"
-					}
-				}
-				s.THRESH[key] = value
-			}
-		}
-	}
-	i++
-	if i <= dataLen {
-		s.BASER_NCL, _ = strconv.ParseFloat(fields[3], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BASER_NCU, _ = strconv.ParseFloat(fields[4], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.RELIABILITY, _ = strconv.ParseFloat(fields[5], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.RESOLUTION, _ = strconv.ParseFloat(fields[6], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.UNCERTAINTY, _ = strconv.ParseFloat(fields[7], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ROC_AUC, _ = strconv.ParseFloat(fields[8], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BRIER, _ = strconv.ParseFloat(fields[9], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BRIER_NCL, _ = strconv.ParseFloat(fields[10], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BRIER_NCU, _ = strconv.ParseFloat(fields[11], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BRIERCL, _ = strconv.ParseFloat(fields[12], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BRIERCL_NCL, _ = strconv.ParseFloat(fields[13], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BRIERCL_NCU, _ = strconv.ParseFloat(fields[14], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BSS, _ = strconv.ParseFloat(fields[15], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BSS_SMPL, _ = strconv.ParseFloat(fields[16], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.THRESH_I, _ = strconv.Atoi(fields[17])
-	}
-}
-
-func (s *STAT_ECLV) fill_STAT_ECLV(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen {
-		s.BASER, _ = strconv.ParseFloat(fields[1], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.VALUE_BASER, _ = strconv.Atoi(fields[2])
-	}
-	i++
-	if i <= dataLen { // the first field of the repeating fields is the TOTAL, the second field is the 1st dimenSion of the 1st sequence (there might be only one sequence)
-		var value interface{}
-		count, err := strconv.Atoi(fields[3])
-		if err != nil {
-			count = 0
-		}
-		keyPrefixes := []string{"CL_", "VALUE_"}
-		s.PTS = make(map[string]interface{})
-		for group := 1; group <= count; group++ {
-			for index := 4; index <= len(keyPrefixes); index++ {
-				key := fmt.Sprintf("%s_%d", keyPrefixes[index-1], index)
-				if index > len(fields) { // sometimes the data line is truncated - we will set expected data to "NA"
-					value = "NA"
-				} else {
-					value, err = strconv.ParseFloat(fields[index], 64)
-					if err != nil { // sometimes there can be these NA values in the data, which will be left out of json
-						value = "NA"
-					}
-				}
-				s.PTS[key] = value
-			}
-		}
-	}
-}
-
-func (s *STAT_SSVAR) fill_STAT_SSVAR(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen {
-		s.N_BIN, _ = strconv.Atoi(fields[1])
-	}
-	i++
-	if i <= dataLen {
-		s.BIN_I, _ = strconv.Atoi(fields[2])
-	}
-	i++
-	if i <= dataLen {
-		s.BIN_N, _ = strconv.Atoi(fields[3])
-	}
-	i++
-	if i <= dataLen {
-		s.VAR_MIN, _ = strconv.ParseFloat(fields[4], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.VAR_MAX, _ = strconv.ParseFloat(fields[5], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.VAR_MEAN, _ = strconv.ParseFloat(fields[6], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FBAR, _ = strconv.ParseFloat(fields[7], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OBAR, _ = strconv.ParseFloat(fields[8], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FOBAR, _ = strconv.ParseFloat(fields[9], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FFBAR, _ = strconv.ParseFloat(fields[10], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OOBAR, _ = strconv.ParseFloat(fields[11], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FBAR_NCL, _ = strconv.ParseFloat(fields[12], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FBAR_NCU, _ = strconv.ParseFloat(fields[13], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FSTDEV, _ = strconv.ParseFloat(fields[14], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FSTDEV_NCL, _ = strconv.ParseFloat(fields[15], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FSTDEV_NCU, _ = strconv.ParseFloat(fields[16], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OBAR_NCL, _ = strconv.ParseFloat(fields[17], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OBAR_NCU, _ = strconv.ParseFloat(fields[18], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OSTDEV, _ = strconv.ParseFloat(fields[19], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OSTDEV_NCL, _ = strconv.ParseFloat(fields[20], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OSTDEV_NCU, _ = strconv.ParseFloat(fields[21], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.PR_CORR, _ = strconv.ParseFloat(fields[22], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.PR_CORR_NCL, _ = strconv.ParseFloat(fields[23], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.PR_CORR_NCU, _ = strconv.ParseFloat(fields[24], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ME, _ = strconv.ParseFloat(fields[25], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ME_NCL, _ = strconv.ParseFloat(fields[26], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ME_NCU, _ = strconv.ParseFloat(fields[27], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ESTDEV, _ = strconv.ParseFloat(fields[28], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ESTDEV_NCL, _ = strconv.ParseFloat(fields[29], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ESTDEV_NCU, _ = strconv.ParseFloat(fields[30], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.MBIAS, _ = strconv.ParseFloat(fields[31], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.MSE, _ = strconv.ParseFloat(fields[32], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BCMSE, _ = strconv.ParseFloat(fields[33], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.RMSE, _ = strconv.ParseFloat(fields[34], 64)
-	}
-}
-
-func (s *MODE_CTS) fill_MODE_CTS(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.FIELD = fields[0]
-	}
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[1])
-	}
-	i++
-	if i <= dataLen {
-		s.FY_OY, _ = strconv.ParseFloat(fields[2], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FY_ON, _ = strconv.ParseFloat(fields[3], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FN_OY, _ = strconv.ParseFloat(fields[4], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FN_ON, _ = strconv.ParseFloat(fields[5], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BASER, _ = strconv.ParseFloat(fields[6], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FMEAN, _ = strconv.ParseFloat(fields[7], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ACC, _ = strconv.ParseFloat(fields[8], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FBIAS, _ = strconv.ParseFloat(fields[9], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.PODY, _ = strconv.ParseFloat(fields[10], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.PODN, _ = strconv.ParseFloat(fields[11], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.POFD, _ = strconv.ParseFloat(fields[12], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FAR, _ = strconv.ParseFloat(fields[13], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CSI, _ = strconv.ParseFloat(fields[14], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.GSS, _ = strconv.ParseFloat(fields[15], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HK, _ = strconv.ParseFloat(fields[16], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HSS, _ = strconv.ParseFloat(fields[17], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ODDS, _ = strconv.ParseFloat(fields[18], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.LODDS, _ = strconv.ParseFloat(fields[19], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ORSS, _ = strconv.ParseFloat(fields[20], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.EDS, _ = strconv.ParseFloat(fields[21], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SEDS, _ = strconv.ParseFloat(fields[22], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.EDI, _ = strconv.ParseFloat(fields[23], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SEDI, _ = strconv.ParseFloat(fields[24], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BAGSS, _ = strconv.ParseFloat(fields[25], 64)
-	}
-}
-
-func (s *MTD_2DSINGLE) fill_MTD_2DSINGLE(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.OBJECT_ID = fields[0]
-	}
-	i++
-	if i <= dataLen {
-		s.OBJECT_CAT = fields[1]
-	}
-	i++
-	if i <= dataLen {
-		s.TIME_INDEX, _ = strconv.Atoi(fields[2])
-	}
-	i++
-	if i <= dataLen {
-		s.AREA, _ = strconv.Atoi(fields[3])
-	}
-	i++
-	if i <= dataLen {
-		s.CENTROID_X, _ = strconv.ParseFloat(fields[4], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CENTROID_Y, _ = strconv.ParseFloat(fields[5], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CENTROID_LAT, _ = strconv.ParseFloat(fields[6], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CENTROID_LON, _ = strconv.ParseFloat(fields[7], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AXIS_ANG, _ = strconv.ParseFloat(fields[8], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTENSITY_10, _ = strconv.ParseFloat(fields[9], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTENSITY_25, _ = strconv.ParseFloat(fields[10], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTENSITY_50, _ = strconv.ParseFloat(fields[11], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTENSITY_75, _ = strconv.ParseFloat(fields[12], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTENSITY_90, _ = strconv.ParseFloat(fields[13], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTENSITY_USER, _ = strconv.ParseFloat(fields[14], 64)
-	}
-}
-
-func (s *STAT_CTC) fill_STAT_CTC(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen {
-		s.FY_OY, _ = strconv.ParseFloat(fields[1], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FY_ON, _ = strconv.ParseFloat(fields[2], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FN_OY, _ = strconv.ParseFloat(fields[3], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FN_ON, _ = strconv.ParseFloat(fields[4], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.EC_VALUE, _ = strconv.ParseFloat(fields[5], 64)
-	}
-}
-
-func (s *STAT_VL1L2) fill_STAT_VL1L2(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen {
-		s.UFBAR, _ = strconv.ParseFloat(fields[1], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.VFBAR, _ = strconv.ParseFloat(fields[2], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.UOBAR, _ = strconv.ParseFloat(fields[3], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.VOBAR, _ = strconv.ParseFloat(fields[4], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.UVFOBAR, _ = strconv.ParseFloat(fields[5], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.UVFFBAR, _ = strconv.ParseFloat(fields[6], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.UVOOBAR, _ = strconv.ParseFloat(fields[7], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.F_SPEED_BAR, _ = strconv.ParseFloat(fields[8], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.O_SPEED_BAR, _ = strconv.ParseFloat(fields[9], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.TOTAL_DIR, _ = strconv.ParseFloat(fields[10], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.DIR_ME, _ = strconv.ParseFloat(fields[11], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.DIR_MAE, _ = strconv.ParseFloat(fields[12], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.DIR_MSE, _ = strconv.ParseFloat(fields[13], 64)
-	}
-}
-
-func (s *STAT_GENMPR) fill_STAT_GENMPR(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen {
-		s.INDEX, _ = strconv.Atoi(fields[1])
-	}
-	i++
-	if i <= dataLen {
-		s.STORM_ID = fields[2]
-	}
-	i++
-	if i <= dataLen {
-		s.PROB_LEAD, _ = strconv.ParseFloat(fields[3], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.PROB_VAL, _ = strconv.ParseFloat(fields[4], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AGEN_INIT = fields[5]
-	}
-	i++
-	if i <= dataLen {
-		s.AGEN_FHR = fields[6]
-	}
-	i++
-	if i <= dataLen {
-		s.AGEN_LAT, _ = strconv.ParseFloat(fields[7], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AGEN_LON, _ = strconv.ParseFloat(fields[8], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AGEN_DLAND, _ = strconv.ParseFloat(fields[9], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BGEN_LAT, _ = strconv.ParseFloat(fields[10], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BGEN_LON, _ = strconv.ParseFloat(fields[11], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BGEN_DLAND, _ = strconv.ParseFloat(fields[12], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.GEN_DIST, _ = strconv.ParseFloat(fields[13], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.GEN_TDIFF = fields[14]
-	}
-	i++
-	if i <= dataLen {
-		s.INIT_TDIFF = fields[15]
-	}
-	i++
-	if i <= dataLen {
-		s.DEV_CAT = fields[16]
-	}
-	i++
-	if i <= dataLen {
-		s.OPS_CAT = fields[17]
-	}
-}
-
-func (s *TCST_PROBRIRW) fill_TCST_PROBRIRW(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.ALAT, _ = strconv.ParseFloat(fields[0], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ALON, _ = strconv.ParseFloat(fields[1], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BLAT, _ = strconv.ParseFloat(fields[2], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BLON, _ = strconv.ParseFloat(fields[3], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INITIALS = fields[4]
-	}
-	i++
-	if i <= dataLen {
-		s.TK_ERR, _ = strconv.ParseFloat(fields[5], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.X_ERR, _ = strconv.ParseFloat(fields[6], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.Y_ERR, _ = strconv.ParseFloat(fields[7], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ADLAND, _ = strconv.ParseFloat(fields[8], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BDLAND, _ = strconv.ParseFloat(fields[9], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.RIRW_BEG, _ = strconv.Atoi(fields[10])
-	}
-	i++
-	if i <= dataLen {
-		s.RIRW_END, _ = strconv.Atoi(fields[11])
-	}
-	i++
-	if i <= dataLen {
-		s.RIRW_WINDOW, _ = strconv.Atoi(fields[12])
-	}
-	i++
-	if i <= dataLen {
-		s.AWIND_END, _ = strconv.ParseFloat(fields[13], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BWIND_BEG, _ = strconv.ParseFloat(fields[14], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BWIND_END, _ = strconv.ParseFloat(fields[15], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BDELTA, _ = strconv.ParseFloat(fields[16], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BDELTA_MAX, _ = strconv.ParseFloat(fields[17], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BLEVEL_BEG = fields[18]
-	}
-	i++
-	if i <= dataLen {
-		s.BLEVEL_END = fields[19]
-	}
-	i++
-	if i <= dataLen { // the first field of the repeating fields is the TOTAL, the second field is the 1st dimenSion of the 1st sequence (there might be only one sequence)
-		var value interface{}
-		count, err := strconv.Atoi(fields[20])
-		if err != nil {
-			count = 0
-		}
-		keyPrefixes := []string{"THRESH_", "PROB_"}
-		s.THRESH = make(map[string]interface{})
-		for group := 1; group <= count; group++ {
-			for index := 21; index <= len(keyPrefixes); index++ {
-				key := fmt.Sprintf("%s_%d", keyPrefixes[index-1], index)
-				if index > len(fields) { // sometimes the data line is truncated - we will set expected data to "NA"
-					value = "NA"
-				} else {
-					value, err = strconv.Atoi(fields[index])
-					if err != nil { // sometimes there can be these NA values in the data, which will be left out of json
-						value = "NA"
-					}
-				}
-				s.THRESH[key] = value
-			}
-		}
-	}
-}
-
-func (s *STAT_FHO) fill_STAT_FHO(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen {
-		s.F_RATE, _ = strconv.ParseFloat(fields[1], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.H_RATE, _ = strconv.ParseFloat(fields[2], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.O_RATE, _ = strconv.ParseFloat(fields[3], 64)
-	}
-}
-
-func (s *STAT_SSIDX) fill_STAT_SSIDX(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.FCST_MODEL = fields[0]
-	}
-	i++
-	if i <= dataLen {
-		s.REF_MODEL = fields[1]
-	}
-	i++
-	if i <= dataLen {
-		s.N_INIT, _ = strconv.Atoi(fields[2])
-	}
-	i++
-	if i <= dataLen {
-		s.N_TERM, _ = strconv.Atoi(fields[3])
-	}
-	i++
-	if i <= dataLen {
-		s.N_VLD, _ = strconv.Atoi(fields[4])
-	}
-	i++
-	if i <= dataLen {
-		s.SS_INDEX, _ = strconv.ParseFloat(fields[5], 64)
 	}
 }
 
@@ -7280,7 +6074,7 @@ func (s *STAT_CNT) fill_STAT_CNT(fields []string) {
 	}
 }
 
-func (s *STAT_NBRCNT) fill_STAT_NBRCNT(fields []string) {
+func (s *STAT_ISC) fill_STAT_ISC(fields []string) {
 	dataLen := len(fields) - 1
 	i := -1
 	i++
@@ -7289,75 +6083,47 @@ func (s *STAT_NBRCNT) fill_STAT_NBRCNT(fields []string) {
 	}
 	i++
 	if i <= dataLen {
-		s.FBS, _ = strconv.ParseFloat(fields[1], 64)
+		s.TILE_DIM, _ = strconv.Atoi(fields[1])
 	}
 	i++
 	if i <= dataLen {
-		s.FBS_BCL, _ = strconv.ParseFloat(fields[2], 64)
+		s.TILE_XLL, _ = strconv.Atoi(fields[2])
 	}
 	i++
 	if i <= dataLen {
-		s.FBS_BCU, _ = strconv.ParseFloat(fields[3], 64)
+		s.TILE_YLL, _ = strconv.Atoi(fields[3])
 	}
 	i++
 	if i <= dataLen {
-		s.FSS, _ = strconv.ParseFloat(fields[4], 64)
+		s.NSCALE, _ = strconv.Atoi(fields[4])
 	}
 	i++
 	if i <= dataLen {
-		s.FSS_BCL, _ = strconv.ParseFloat(fields[5], 64)
+		s.ISCALE, _ = strconv.Atoi(fields[5])
 	}
 	i++
 	if i <= dataLen {
-		s.FSS_BCU, _ = strconv.ParseFloat(fields[6], 64)
+		s.MSE, _ = strconv.ParseFloat(fields[6], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.AFSS, _ = strconv.ParseFloat(fields[7], 64)
+		s.ISC, _ = strconv.ParseFloat(fields[7], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.AFSS_BCL, _ = strconv.ParseFloat(fields[8], 64)
+		s.FENERGY2, _ = strconv.ParseFloat(fields[8], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.AFSS_BCU, _ = strconv.ParseFloat(fields[9], 64)
+		s.OENERGY2, _ = strconv.ParseFloat(fields[9], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.UFSS, _ = strconv.ParseFloat(fields[10], 64)
+		s.BASER, _ = strconv.ParseFloat(fields[10], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.UFSS_BCL, _ = strconv.ParseFloat(fields[11], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.UFSS_BCU, _ = strconv.ParseFloat(fields[12], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.F_RATE, _ = strconv.ParseFloat(fields[13], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.F_RATE_BCL, _ = strconv.ParseFloat(fields[14], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.F_RATE_BCU, _ = strconv.ParseFloat(fields[15], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.O_RATE, _ = strconv.ParseFloat(fields[16], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.O_RATE_BCL, _ = strconv.ParseFloat(fields[17], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.O_RATE_BCU, _ = strconv.ParseFloat(fields[18], 64)
+		s.FBIAS, _ = strconv.ParseFloat(fields[11], 64)
 	}
 }
 
@@ -7783,7 +6549,40 @@ func (s *STAT_GRAD) fill_STAT_GRAD(fields []string) {
 	}
 }
 
-func (s *STAT_SEEPS) fill_STAT_SEEPS(fields []string) {
+func (s *STAT_PCT) fill_STAT_PCT(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen { // the first field of the repeating fields is the TOTAL, the second field is the 1st dimenSion of the 1st sequence (there might be only one sequence)
+		var value interface{}
+		count, err := strconv.Atoi(fields[1])
+		if err != nil {
+			count = 0
+		}
+		keyPrefixes := []string{"THRESH_", "OY_", "ON_"}
+		s.THRESH = make(map[string]interface{})
+		for group := 1; group <= count; group++ {
+			for index := 2; index <= len(keyPrefixes); index++ {
+				key := fmt.Sprintf("%s_%d", keyPrefixes[index-1], index)
+				if index > len(fields) { // sometimes the data line is truncated - we will set expected data to "NA"
+					value = "NA"
+				} else {
+					value, err = strconv.ParseFloat(fields[index], 64)
+					if err != nil { // sometimes there can be these NA values in the data, which will be left out of json
+						value = "NA"
+					}
+				}
+				s.THRESH[key] = value
+			}
+		}
+	}
+}
+
+func (s *STAT_RPS) fill_STAT_RPS(fields []string) {
 	dataLen := len(fields) - 1
 	i := -1
 	i++
@@ -7792,63 +6591,1080 @@ func (s *STAT_SEEPS) fill_STAT_SEEPS(fields []string) {
 	}
 	i++
 	if i <= dataLen {
-		s.ODFL, _ = strconv.ParseFloat(fields[1], 64)
+		s.N_PROB, _ = strconv.Atoi(fields[1])
 	}
 	i++
 	if i <= dataLen {
-		s.ODFH, _ = strconv.ParseFloat(fields[2], 64)
+		s.RPS_REL, _ = strconv.ParseFloat(fields[2], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.OLFD, _ = strconv.ParseFloat(fields[3], 64)
+		s.RPS_RES, _ = strconv.ParseFloat(fields[3], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.OLFH, _ = strconv.ParseFloat(fields[4], 64)
+		s.RPS_UNC, _ = strconv.ParseFloat(fields[4], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.OHFD, _ = strconv.ParseFloat(fields[5], 64)
+		s.RPS, _ = strconv.ParseFloat(fields[5], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.OHFL, _ = strconv.ParseFloat(fields[6], 64)
+		s.RPSS, _ = strconv.ParseFloat(fields[6], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.PF1, _ = strconv.ParseFloat(fields[7], 64)
+		s.RPSS_SMPL, _ = strconv.ParseFloat(fields[7], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.PF2, _ = strconv.ParseFloat(fields[8], 64)
+		s.RPS_COMP, _ = strconv.ParseFloat(fields[8], 64)
+	}
+}
+
+func (s *STAT_SAL1L2) fill_STAT_SAL1L2(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
 	}
 	i++
 	if i <= dataLen {
-		s.PF3, _ = strconv.ParseFloat(fields[9], 64)
+		s.FABAR, _ = strconv.ParseFloat(fields[1], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.PV1, _ = strconv.ParseFloat(fields[10], 64)
+		s.OABAR, _ = strconv.ParseFloat(fields[2], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.PV2, _ = strconv.ParseFloat(fields[11], 64)
+		s.FOABAR, _ = strconv.ParseFloat(fields[3], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.PV3, _ = strconv.ParseFloat(fields[12], 64)
+		s.FFABAR, _ = strconv.ParseFloat(fields[4], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.MEAN_FCST, _ = strconv.ParseFloat(fields[13], 64)
+		s.OOABAR, _ = strconv.ParseFloat(fields[5], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.MEAN_OBS, _ = strconv.ParseFloat(fields[14], 64)
+		s.MAE, _ = strconv.ParseFloat(fields[6], 64)
+	}
+}
+
+func (s *STAT_SL1L2) fill_STAT_SL1L2(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
 	}
 	i++
 	if i <= dataLen {
-		s.SEEPS, _ = strconv.ParseFloat(fields[15], 64)
+		s.FBAR, _ = strconv.ParseFloat(fields[1], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OBAR, _ = strconv.ParseFloat(fields[2], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FOBAR, _ = strconv.ParseFloat(fields[3], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FFBAR, _ = strconv.ParseFloat(fields[4], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OOBAR, _ = strconv.ParseFloat(fields[5], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.MAE, _ = strconv.ParseFloat(fields[6], 64)
+	}
+}
+
+func (s *STAT_CTS) fill_STAT_CTS(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen {
+		s.BASER, _ = strconv.ParseFloat(fields[1], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BASER_NCL, _ = strconv.ParseFloat(fields[2], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BASER_NCU, _ = strconv.ParseFloat(fields[3], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BASER_BCL, _ = strconv.ParseFloat(fields[4], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BASER_BCU, _ = strconv.ParseFloat(fields[5], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FMEAN, _ = strconv.ParseFloat(fields[6], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FMEAN_NCL, _ = strconv.ParseFloat(fields[7], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FMEAN_NCU, _ = strconv.ParseFloat(fields[8], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FMEAN_BCL, _ = strconv.ParseFloat(fields[9], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FMEAN_BCU, _ = strconv.ParseFloat(fields[10], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ACC, _ = strconv.ParseFloat(fields[11], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ACC_NCL, _ = strconv.ParseFloat(fields[12], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ACC_NCU, _ = strconv.ParseFloat(fields[13], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ACC_BCL, _ = strconv.ParseFloat(fields[14], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ACC_BCU, _ = strconv.ParseFloat(fields[15], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FBIAS, _ = strconv.ParseFloat(fields[16], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FBIAS_BCL, _ = strconv.ParseFloat(fields[17], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FBIAS_BCU, _ = strconv.ParseFloat(fields[18], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PODY, _ = strconv.ParseFloat(fields[19], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PODY_NCL, _ = strconv.ParseFloat(fields[20], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PODY_NCU, _ = strconv.ParseFloat(fields[21], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PODY_BCL, _ = strconv.ParseFloat(fields[22], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PODY_BCU, _ = strconv.ParseFloat(fields[23], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PODN, _ = strconv.ParseFloat(fields[24], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PODN_NCL, _ = strconv.ParseFloat(fields[25], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PODN_NCU, _ = strconv.ParseFloat(fields[26], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PODN_BCL, _ = strconv.ParseFloat(fields[27], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PODN_BCU, _ = strconv.ParseFloat(fields[28], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.POFD, _ = strconv.ParseFloat(fields[29], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.POFD_NCL, _ = strconv.ParseFloat(fields[30], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.POFD_NCU, _ = strconv.ParseFloat(fields[31], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.POFD_BCL, _ = strconv.ParseFloat(fields[32], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.POFD_BCU, _ = strconv.ParseFloat(fields[33], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FAR, _ = strconv.ParseFloat(fields[34], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FAR_NCL, _ = strconv.ParseFloat(fields[35], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FAR_NCU, _ = strconv.ParseFloat(fields[36], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FAR_BCL, _ = strconv.ParseFloat(fields[37], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FAR_BCU, _ = strconv.ParseFloat(fields[38], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CSI, _ = strconv.ParseFloat(fields[39], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CSI_NCL, _ = strconv.ParseFloat(fields[40], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CSI_NCU, _ = strconv.ParseFloat(fields[41], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CSI_BCL, _ = strconv.ParseFloat(fields[42], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CSI_BCU, _ = strconv.ParseFloat(fields[43], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.GSS, _ = strconv.ParseFloat(fields[44], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.GSS_BCL, _ = strconv.ParseFloat(fields[45], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.GSS_BCU, _ = strconv.ParseFloat(fields[46], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HK, _ = strconv.ParseFloat(fields[47], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HK_NCL, _ = strconv.ParseFloat(fields[48], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HK_NCU, _ = strconv.ParseFloat(fields[49], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HK_BCL, _ = strconv.ParseFloat(fields[50], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HK_BCU, _ = strconv.ParseFloat(fields[51], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HSS, _ = strconv.ParseFloat(fields[52], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HSS_BCL, _ = strconv.ParseFloat(fields[53], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HSS_BCU, _ = strconv.ParseFloat(fields[54], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ODDS, _ = strconv.ParseFloat(fields[55], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ODDS_NCL, _ = strconv.ParseFloat(fields[56], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ODDS_NCU, _ = strconv.ParseFloat(fields[57], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ODDS_BCL, _ = strconv.ParseFloat(fields[58], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ODDS_BCU, _ = strconv.ParseFloat(fields[59], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.LODDS, _ = strconv.ParseFloat(fields[60], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.LODDS_NCL, _ = strconv.ParseFloat(fields[61], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.LODDS_NCU, _ = strconv.ParseFloat(fields[62], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.LODDS_BCL, _ = strconv.ParseFloat(fields[63], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.LODDS_BCU, _ = strconv.ParseFloat(fields[64], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ORSS, _ = strconv.ParseFloat(fields[65], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ORSS_NCL, _ = strconv.ParseFloat(fields[66], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ORSS_NCU, _ = strconv.ParseFloat(fields[67], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ORSS_BCL, _ = strconv.ParseFloat(fields[68], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ORSS_BCU, _ = strconv.ParseFloat(fields[69], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.EDS, _ = strconv.ParseFloat(fields[70], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.EDS_NCL, _ = strconv.ParseFloat(fields[71], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.EDS_NCU, _ = strconv.ParseFloat(fields[72], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.EDS_BCL, _ = strconv.ParseFloat(fields[73], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.EDS_BCU, _ = strconv.ParseFloat(fields[74], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SEDS, _ = strconv.ParseFloat(fields[75], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SEDS_NCL, _ = strconv.ParseFloat(fields[76], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SEDS_NCU, _ = strconv.ParseFloat(fields[77], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SEDS_BCL, _ = strconv.ParseFloat(fields[78], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SEDS_BCU, _ = strconv.ParseFloat(fields[79], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.EDI, _ = strconv.ParseFloat(fields[80], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.EDI_NCL, _ = strconv.ParseFloat(fields[81], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.EDI_NCU, _ = strconv.ParseFloat(fields[82], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.EDI_BCL, _ = strconv.ParseFloat(fields[83], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.EDI_BCU, _ = strconv.ParseFloat(fields[84], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SEDI, _ = strconv.ParseFloat(fields[85], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SEDI_NCL, _ = strconv.ParseFloat(fields[86], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SEDI_NCU, _ = strconv.ParseFloat(fields[87], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SEDI_BCL, _ = strconv.ParseFloat(fields[88], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SEDI_BCU, _ = strconv.ParseFloat(fields[89], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BAGSS, _ = strconv.ParseFloat(fields[90], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BAGSS_BCL, _ = strconv.ParseFloat(fields[91], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BAGSS_BCU, _ = strconv.ParseFloat(fields[92], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HSS_EC, _ = strconv.ParseFloat(fields[93], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HSS_EC_BCL, _ = strconv.ParseFloat(fields[94], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HSS_EC_BCU, _ = strconv.ParseFloat(fields[95], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.EC_VALUE, _ = strconv.ParseFloat(fields[96], 64)
+	}
+}
+
+func (s *STAT_MCTC) fill_STAT_MCTC(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen { // these values seem to always be ints (or "NA")
+		var value interface{}
+		count, err := strconv.Atoi(fields[1])
+		if err != nil {
+			count = 0
+		}
+		s.CAT = make(map[string]interface{})
+		for i1 := 1; i1 <= count; i1++ {
+			for i2 := 1; i2 <= count; i2++ {
+				// generate the particular key for the map i.e. F1_O1, F1_O2, F1_O3, F1_O4, F2_O1, F2_O2, F2_O3, F2_O4, etc.
+				key := fmt.Sprintf("F%d_O%d", i1, i2)
+				index := (i1-1)*count + i2
+				if index >= len(fields) {
+					value = "NA"
+				} else {
+					value, err = strconv.Atoi(fields[index])
+				}
+				if err != nil {
+					value = "NA"
+				}
+				s.CAT[key] = value
+			}
+		}
+	}
+	i++
+	if i <= dataLen {
+		s.EC_VALUE, _ = strconv.ParseFloat(fields[3], 64)
+	}
+}
+
+func (s *STAT_SEEPS_MPR) fill_STAT_SEEPS_MPR(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.OBS_SID = fields[0]
+	}
+	i++
+	if i <= dataLen {
+		s.OBS_LAT, _ = strconv.ParseFloat(fields[1], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OBS_LON, _ = strconv.ParseFloat(fields[2], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FCST, _ = strconv.ParseFloat(fields[3], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OBS, _ = strconv.ParseFloat(fields[4], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OBS_QC = fields[5]
+	}
+	i++
+	if i <= dataLen {
+		s.FCST_CAT, _ = strconv.Atoi(fields[6])
+	}
+	i++
+	if i <= dataLen {
+		s.OBS_CAT, _ = strconv.Atoi(fields[7])
+	}
+	i++
+	if i <= dataLen {
+		s.P1, _ = strconv.ParseFloat(fields[8], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.P2, _ = strconv.ParseFloat(fields[9], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.T1, _ = strconv.ParseFloat(fields[10], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.T2, _ = strconv.ParseFloat(fields[11], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SEEPS, _ = strconv.ParseFloat(fields[12], 64)
+	}
+}
+
+func (s *MTD_2DSINGLE) fill_MTD_2DSINGLE(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.OBJECT_ID = fields[0]
+	}
+	i++
+	if i <= dataLen {
+		s.OBJECT_CAT = fields[1]
+	}
+	i++
+	if i <= dataLen {
+		s.TIME_INDEX, _ = strconv.Atoi(fields[2])
+	}
+	i++
+	if i <= dataLen {
+		s.AREA, _ = strconv.Atoi(fields[3])
+	}
+	i++
+	if i <= dataLen {
+		s.CENTROID_X, _ = strconv.ParseFloat(fields[4], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CENTROID_Y, _ = strconv.ParseFloat(fields[5], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CENTROID_LAT, _ = strconv.ParseFloat(fields[6], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CENTROID_LON, _ = strconv.ParseFloat(fields[7], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.AXIS_ANG, _ = strconv.ParseFloat(fields[8], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTENSITY_10, _ = strconv.ParseFloat(fields[9], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTENSITY_25, _ = strconv.ParseFloat(fields[10], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTENSITY_50, _ = strconv.ParseFloat(fields[11], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTENSITY_75, _ = strconv.ParseFloat(fields[12], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTENSITY_90, _ = strconv.ParseFloat(fields[13], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTENSITY_USER, _ = strconv.ParseFloat(fields[14], 64)
+	}
+}
+
+func (s *STAT_ECNT) fill_STAT_ECNT(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen {
+		s.N_ENS, _ = strconv.Atoi(fields[1])
+	}
+	i++
+	if i <= dataLen {
+		s.CRPS, _ = strconv.ParseFloat(fields[2], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CRPSS, _ = strconv.ParseFloat(fields[3], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.IGN, _ = strconv.ParseFloat(fields[4], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ME, _ = strconv.ParseFloat(fields[5], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.RMSE, _ = strconv.ParseFloat(fields[6], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SPREAD, _ = strconv.ParseFloat(fields[7], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ME_OERR, _ = strconv.ParseFloat(fields[8], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.RMSE_OERR, _ = strconv.ParseFloat(fields[9], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SPREAD_OERR, _ = strconv.ParseFloat(fields[10], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SPREAD_PLUS_OERR, _ = strconv.ParseFloat(fields[11], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CRPSCL, _ = strconv.ParseFloat(fields[12], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CRPS_EMP, _ = strconv.ParseFloat(fields[13], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CRPSCL_EMP, _ = strconv.ParseFloat(fields[14], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CRPSS_EMP, _ = strconv.ParseFloat(fields[15], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CRPS_EMP_FAIR, _ = strconv.ParseFloat(fields[16], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SPREAD_MD, _ = strconv.ParseFloat(fields[17], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.MAE, _ = strconv.ParseFloat(fields[18], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.MAE_OERR, _ = strconv.ParseFloat(fields[19], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BIAS_RATIO, _ = strconv.ParseFloat(fields[20], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.N_GE_OBS, _ = strconv.Atoi(fields[21])
+	}
+	i++
+	if i <= dataLen {
+		s.ME_GE_OBS, _ = strconv.ParseFloat(fields[22], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.N_LT_OBS, _ = strconv.Atoi(fields[23])
+	}
+	i++
+	if i <= dataLen {
+		s.ME_LT_OBS, _ = strconv.ParseFloat(fields[24], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.IGN_CONV_OERR, _ = strconv.ParseFloat(fields[25], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.IGN_CORR_OERR, _ = strconv.ParseFloat(fields[26], 64)
+	}
+}
+
+func (s *STAT_VAL1L2) fill_STAT_VAL1L2(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen {
+		s.UFABAR, _ = strconv.ParseFloat(fields[1], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.VFABAR, _ = strconv.ParseFloat(fields[2], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.UOABAR, _ = strconv.ParseFloat(fields[3], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.VOABAR, _ = strconv.ParseFloat(fields[4], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.UVFOABAR, _ = strconv.ParseFloat(fields[5], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.UVFFABAR, _ = strconv.ParseFloat(fields[6], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.UVOOABAR, _ = strconv.ParseFloat(fields[7], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FA_SPEED_BAR, _ = strconv.ParseFloat(fields[8], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OA_SPEED_BAR, _ = strconv.ParseFloat(fields[9], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.TOTAL_DIR, _ = strconv.ParseFloat(fields[10], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.DIRA_ME, _ = strconv.ParseFloat(fields[11], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.DIRA_MAE, _ = strconv.ParseFloat(fields[12], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.DIRA_MSE, _ = strconv.ParseFloat(fields[13], 64)
+	}
+}
+
+func (s *STAT_SSIDX) fill_STAT_SSIDX(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.FCST_MODEL = fields[0]
+	}
+	i++
+	if i <= dataLen {
+		s.REF_MODEL = fields[1]
+	}
+	i++
+	if i <= dataLen {
+		s.N_INIT, _ = strconv.Atoi(fields[2])
+	}
+	i++
+	if i <= dataLen {
+		s.N_TERM, _ = strconv.Atoi(fields[3])
+	}
+	i++
+	if i <= dataLen {
+		s.N_VLD, _ = strconv.Atoi(fields[4])
+	}
+	i++
+	if i <= dataLen {
+		s.SS_INDEX, _ = strconv.ParseFloat(fields[5], 64)
+	}
+}
+
+func (s *TCST_PROBRIRW) fill_TCST_PROBRIRW(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.ALAT, _ = strconv.ParseFloat(fields[0], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ALON, _ = strconv.ParseFloat(fields[1], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BLAT, _ = strconv.ParseFloat(fields[2], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BLON, _ = strconv.ParseFloat(fields[3], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INITIALS = fields[4]
+	}
+	i++
+	if i <= dataLen {
+		s.TK_ERR, _ = strconv.ParseFloat(fields[5], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.X_ERR, _ = strconv.ParseFloat(fields[6], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.Y_ERR, _ = strconv.ParseFloat(fields[7], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ADLAND, _ = strconv.ParseFloat(fields[8], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BDLAND, _ = strconv.ParseFloat(fields[9], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.RIRW_BEG, _ = strconv.Atoi(fields[10])
+	}
+	i++
+	if i <= dataLen {
+		s.RIRW_END, _ = strconv.Atoi(fields[11])
+	}
+	i++
+	if i <= dataLen {
+		s.RIRW_WINDOW, _ = strconv.Atoi(fields[12])
+	}
+	i++
+	if i <= dataLen {
+		s.AWIND_END, _ = strconv.ParseFloat(fields[13], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BWIND_BEG, _ = strconv.ParseFloat(fields[14], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BWIND_END, _ = strconv.ParseFloat(fields[15], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BDELTA, _ = strconv.ParseFloat(fields[16], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BDELTA_MAX, _ = strconv.ParseFloat(fields[17], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BLEVEL_BEG = fields[18]
+	}
+	i++
+	if i <= dataLen {
+		s.BLEVEL_END = fields[19]
+	}
+	i++
+	if i <= dataLen { // the first field of the repeating fields is the TOTAL, the second field is the 1st dimenSion of the 1st sequence (there might be only one sequence)
+		var value interface{}
+		count, err := strconv.Atoi(fields[20])
+		if err != nil {
+			count = 0
+		}
+		keyPrefixes := []string{"THRESH_", "PROB_"}
+		s.THRESH = make(map[string]interface{})
+		for group := 1; group <= count; group++ {
+			for index := 21; index <= len(keyPrefixes); index++ {
+				key := fmt.Sprintf("%s_%d", keyPrefixes[index-1], index)
+				if index > len(fields) { // sometimes the data line is truncated - we will set expected data to "NA"
+					value = "NA"
+				} else {
+					value, err = strconv.Atoi(fields[index])
+					if err != nil { // sometimes there can be these NA values in the data, which will be left out of json
+						value = "NA"
+					}
+				}
+				s.THRESH[key] = value
+			}
+		}
+	}
+	i++
+	if i <= dataLen {
+		s.INIT, _ = strconv.Atoi(fields[23])
+	}
+}
+
+func (s *STAT_MCTS) fill_STAT_MCTS(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen {
+		s.N_CAT, _ = strconv.Atoi(fields[1])
+	}
+	i++
+	if i <= dataLen {
+		s.ACC, _ = strconv.ParseFloat(fields[2], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ACC_NCL, _ = strconv.ParseFloat(fields[3], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ACC_NCU, _ = strconv.ParseFloat(fields[4], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ACC_BCL, _ = strconv.ParseFloat(fields[5], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ACC_BCU, _ = strconv.ParseFloat(fields[6], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HK, _ = strconv.ParseFloat(fields[7], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HK_BCL, _ = strconv.ParseFloat(fields[8], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HK_BCU, _ = strconv.ParseFloat(fields[9], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HSS, _ = strconv.ParseFloat(fields[10], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HSS_BCL, _ = strconv.ParseFloat(fields[11], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HSS_BCU, _ = strconv.ParseFloat(fields[12], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.GER, _ = strconv.ParseFloat(fields[13], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.GER_BCL, _ = strconv.ParseFloat(fields[14], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.GER_BCU, _ = strconv.ParseFloat(fields[15], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HSS_EC, _ = strconv.ParseFloat(fields[16], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HSS_EC_BCL, _ = strconv.ParseFloat(fields[17], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HSS_EC_BCU, _ = strconv.ParseFloat(fields[18], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.EC_VALUE, _ = strconv.ParseFloat(fields[19], 64)
+	}
+}
+
+func (s *STAT_NBRCTC) fill_STAT_NBRCTC(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen {
+		s.FY_OY, _ = strconv.ParseFloat(fields[1], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FY_ON, _ = strconv.ParseFloat(fields[2], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FN_OY, _ = strconv.ParseFloat(fields[3], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FN_ON, _ = strconv.ParseFloat(fields[4], 64)
 	}
 }
 
@@ -7953,6 +7769,457 @@ func (s *STAT_DMAP) fill_STAT_DMAP(fields []string) {
 	}
 }
 
+func (s *STAT_PRC) fill_STAT_PRC(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen { // the first field of the repeating fields is the TOTAL, the second field is the 1st dimenSion of the 1st sequence (there might be only one sequence)
+		var value interface{}
+		count, err := strconv.Atoi(fields[1])
+		if err != nil {
+			count = 0
+		}
+		keyPrefixes := []string{"THRESH_", "PODY_", "POFD_"}
+		s.THRESH = make(map[string]interface{})
+		for group := 1; group <= count; group++ {
+			for index := 2; index <= len(keyPrefixes); index++ {
+				key := fmt.Sprintf("%s_%d", keyPrefixes[index-1], index)
+				if index > len(fields) { // sometimes the data line is truncated - we will set expected data to "NA"
+					value = "NA"
+				} else {
+					value, err = strconv.ParseFloat(fields[index], 64)
+					if err != nil { // sometimes there can be these NA values in the data, which will be left out of json
+						value = "NA"
+					}
+				}
+				s.THRESH[key] = value
+			}
+		}
+	}
+}
+
+func (s *STAT_RELP) fill_STAT_RELP(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen { // the first field of the repeating fields is the TOTAL, the second field is the 1st dimenSion of the 1st sequence (there might be only one sequence)
+		var value interface{}
+		count, err := strconv.Atoi(fields[1])
+		if err != nil {
+			count = 0
+		}
+		keyPrefixes := []string{"RELP_"}
+		s.ENS = make(map[string]interface{})
+		for group := 1; group <= count; group++ {
+			for index := 2; index <= len(keyPrefixes); index++ {
+				key := fmt.Sprintf("%s_%d", keyPrefixes[index-1], index)
+				if index > len(fields) { // sometimes the data line is truncated - we will set expected data to "NA"
+					value = "NA"
+				} else {
+					value, err = strconv.ParseFloat(fields[index], 64)
+					if err != nil { // sometimes there can be these NA values in the data, which will be left out of json
+						value = "NA"
+					}
+				}
+				s.ENS[key] = value
+			}
+		}
+	}
+}
+
+func (s *STAT_VL1L2) fill_STAT_VL1L2(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen {
+		s.UFBAR, _ = strconv.ParseFloat(fields[1], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.VFBAR, _ = strconv.ParseFloat(fields[2], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.UOBAR, _ = strconv.ParseFloat(fields[3], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.VOBAR, _ = strconv.ParseFloat(fields[4], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.UVFOBAR, _ = strconv.ParseFloat(fields[5], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.UVFFBAR, _ = strconv.ParseFloat(fields[6], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.UVOOBAR, _ = strconv.ParseFloat(fields[7], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.F_SPEED_BAR, _ = strconv.ParseFloat(fields[8], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.O_SPEED_BAR, _ = strconv.ParseFloat(fields[9], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.TOTAL_DIR, _ = strconv.ParseFloat(fields[10], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.DIR_ME, _ = strconv.ParseFloat(fields[11], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.DIR_MAE, _ = strconv.ParseFloat(fields[12], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.DIR_MSE, _ = strconv.ParseFloat(fields[13], 64)
+	}
+}
+
+func (s *STAT_GENMPR) fill_STAT_GENMPR(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen {
+		s.INDEX, _ = strconv.Atoi(fields[1])
+	}
+	i++
+	if i <= dataLen {
+		s.STORM_ID = fields[2]
+	}
+	i++
+	if i <= dataLen {
+		s.PROB_LEAD, _ = strconv.ParseFloat(fields[3], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PROB_VAL, _ = strconv.ParseFloat(fields[4], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.AGEN_INIT = fields[5]
+	}
+	i++
+	if i <= dataLen {
+		s.AGEN_FHR = fields[6]
+	}
+	i++
+	if i <= dataLen {
+		s.AGEN_LAT, _ = strconv.ParseFloat(fields[7], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.AGEN_LON, _ = strconv.ParseFloat(fields[8], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.AGEN_DLAND, _ = strconv.ParseFloat(fields[9], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BGEN_LAT, _ = strconv.ParseFloat(fields[10], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BGEN_LON, _ = strconv.ParseFloat(fields[11], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BGEN_DLAND, _ = strconv.ParseFloat(fields[12], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.GEN_DIST, _ = strconv.ParseFloat(fields[13], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.GEN_TDIFF = fields[14]
+	}
+	i++
+	if i <= dataLen {
+		s.INIT_TDIFF = fields[15]
+	}
+	i++
+	if i <= dataLen {
+		s.DEV_CAT = fields[16]
+	}
+	i++
+	if i <= dataLen {
+		s.OPS_CAT = fields[17]
+	}
+}
+
+func (s *MODE_OBJ) fill_MODE_OBJ(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.OBJECT_ID = fields[0]
+	}
+	i++
+	if i <= dataLen {
+		s.OBJECT_CAT = fields[1]
+	}
+	i++
+	if i <= dataLen {
+		s.CENTROID_X, _ = strconv.ParseFloat(fields[2], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CENTROID_Y, _ = strconv.ParseFloat(fields[3], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CENTROID_LAT, _ = strconv.ParseFloat(fields[4], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CENTROID_LON, _ = strconv.ParseFloat(fields[5], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.AXIS_ANG, _ = strconv.ParseFloat(fields[6], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.LENGTH, _ = strconv.ParseFloat(fields[7], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.WIDTH, _ = strconv.ParseFloat(fields[8], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.AREA, _ = strconv.Atoi(fields[9])
+	}
+	i++
+	if i <= dataLen {
+		s.AREA_THRESH, _ = strconv.Atoi(fields[10])
+	}
+	i++
+	if i <= dataLen {
+		s.CURVATURE, _ = strconv.ParseFloat(fields[11], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CURVATURE_X, _ = strconv.ParseFloat(fields[12], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CURVATURE_Y, _ = strconv.ParseFloat(fields[13], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.COMPLEXITY, _ = strconv.ParseFloat(fields[14], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTENSITY_10, _ = strconv.ParseFloat(fields[15], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTENSITY_25, _ = strconv.ParseFloat(fields[16], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTENSITY_50, _ = strconv.ParseFloat(fields[17], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTENSITY_75, _ = strconv.ParseFloat(fields[18], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTENSITY_90, _ = strconv.ParseFloat(fields[19], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTENSITY_USER, _ = strconv.ParseFloat(fields[20], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTENSITY_SUM, _ = strconv.ParseFloat(fields[21], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CENTROID_DIST, _ = strconv.ParseFloat(fields[22], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BOUNDARY_DIST, _ = strconv.ParseFloat(fields[23], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CONVEX_HULL_DIST, _ = strconv.ParseFloat(fields[24], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ANGLE_DIFF, _ = strconv.ParseFloat(fields[25], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ASPECT_DIFF, _ = strconv.ParseFloat(fields[26], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.AREA_RATIO, _ = strconv.ParseFloat(fields[27], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTERSECTION_AREA, _ = strconv.ParseFloat(fields[28], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.UNION_AREA, _ = strconv.ParseFloat(fields[29], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SYMMETRIC_DIFF, _ = strconv.ParseFloat(fields[30], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTERSECTION_OVER_AREA, _ = strconv.ParseFloat(fields[31], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CURVATURE_RATIO, _ = strconv.ParseFloat(fields[32], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.COMPLEXITY_RATIO, _ = strconv.ParseFloat(fields[33], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PERCENTILE_INTENSITY_RATIO, _ = strconv.ParseFloat(fields[34], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTEREST, _ = strconv.ParseFloat(fields[35], 64)
+	}
+}
+
+func (s *STAT_CTC) fill_STAT_CTC(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen {
+		s.FY_OY, _ = strconv.ParseFloat(fields[1], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FY_ON, _ = strconv.ParseFloat(fields[2], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FN_OY, _ = strconv.ParseFloat(fields[3], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FN_ON, _ = strconv.ParseFloat(fields[4], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.EC_VALUE, _ = strconv.ParseFloat(fields[5], 64)
+	}
+}
+
+func (s *STAT_SEEPS) fill_STAT_SEEPS(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen {
+		s.ODFL, _ = strconv.ParseFloat(fields[1], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ODFH, _ = strconv.ParseFloat(fields[2], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OLFD, _ = strconv.ParseFloat(fields[3], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OLFH, _ = strconv.ParseFloat(fields[4], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OHFD, _ = strconv.ParseFloat(fields[5], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OHFL, _ = strconv.ParseFloat(fields[6], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PF1, _ = strconv.ParseFloat(fields[7], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PF2, _ = strconv.ParseFloat(fields[8], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PF3, _ = strconv.ParseFloat(fields[9], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PV1, _ = strconv.ParseFloat(fields[10], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PV2, _ = strconv.ParseFloat(fields[11], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PV3, _ = strconv.ParseFloat(fields[12], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.MEAN_FCST, _ = strconv.ParseFloat(fields[13], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.MEAN_OBS, _ = strconv.ParseFloat(fields[14], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SEEPS, _ = strconv.ParseFloat(fields[15], 64)
+	}
+}
+
 func (s *STAT_PJC) fill_STAT_PJC(fields []string) {
 	dataLen := len(fields) - 1
 	i := -1
@@ -7983,100 +8250,6 @@ func (s *STAT_PJC) fill_STAT_PJC(fields []string) {
 				s.THRESH[key] = value
 			}
 		}
-	}
-}
-
-func (s *STAT_RHIST) fill_STAT_RHIST(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen { // the first field of the repeating fields is the TOTAL, the second field is the 1st dimenSion of the 1st sequence (there might be only one sequence)
-		var value interface{}
-		count, err := strconv.Atoi(fields[1])
-		if err != nil {
-			count = 0
-		}
-		keyPrefixes := []string{"RANK_"}
-		s.RANK = make(map[string]interface{})
-		for group := 1; group <= count; group++ {
-			for index := 2; index <= len(keyPrefixes); index++ {
-				key := fmt.Sprintf("%s_%d", keyPrefixes[index-1], index)
-				if index > len(fields) { // sometimes the data line is truncated - we will set expected data to "NA"
-					value = "NA"
-				} else {
-					value, err = strconv.Atoi(fields[index])
-					if err != nil { // sometimes there can be these NA values in the data, which will be left out of json
-						value = "NA"
-					}
-				}
-				s.RANK[key] = value
-			}
-		}
-	}
-}
-
-func (s *STAT_VAL1L2) fill_STAT_VAL1L2(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen {
-		s.UFABAR, _ = strconv.ParseFloat(fields[1], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.VFABAR, _ = strconv.ParseFloat(fields[2], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.UOABAR, _ = strconv.ParseFloat(fields[3], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.VOABAR, _ = strconv.ParseFloat(fields[4], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.UVFOABAR, _ = strconv.ParseFloat(fields[5], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.UVFFABAR, _ = strconv.ParseFloat(fields[6], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.UVOOABAR, _ = strconv.ParseFloat(fields[7], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FA_SPEED_BAR, _ = strconv.ParseFloat(fields[8], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OA_SPEED_BAR, _ = strconv.ParseFloat(fields[9], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.TOTAL_DIR, _ = strconv.ParseFloat(fields[10], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.DIRA_ME, _ = strconv.ParseFloat(fields[11], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.DIRA_MAE, _ = strconv.ParseFloat(fields[12], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.DIRA_MSE, _ = strconv.ParseFloat(fields[13], 64)
 	}
 }
 
@@ -8165,124 +8338,6 @@ func (s *MTD_3DSINGLE) fill_MTD_3DSINGLE(fields []string) {
 	}
 }
 
-func (s *STAT_MCTS) fill_STAT_MCTS(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen {
-		s.N_CAT, _ = strconv.Atoi(fields[1])
-	}
-	i++
-	if i <= dataLen {
-		s.ACC, _ = strconv.ParseFloat(fields[2], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ACC_NCL, _ = strconv.ParseFloat(fields[3], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ACC_NCU, _ = strconv.ParseFloat(fields[4], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ACC_BCL, _ = strconv.ParseFloat(fields[5], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ACC_BCU, _ = strconv.ParseFloat(fields[6], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HK, _ = strconv.ParseFloat(fields[7], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HK_BCL, _ = strconv.ParseFloat(fields[8], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HK_BCU, _ = strconv.ParseFloat(fields[9], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HSS, _ = strconv.ParseFloat(fields[10], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HSS_BCL, _ = strconv.ParseFloat(fields[11], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HSS_BCU, _ = strconv.ParseFloat(fields[12], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.GER, _ = strconv.ParseFloat(fields[13], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.GER_BCL, _ = strconv.ParseFloat(fields[14], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.GER_BCU, _ = strconv.ParseFloat(fields[15], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HSS_EC, _ = strconv.ParseFloat(fields[16], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HSS_EC_BCL, _ = strconv.ParseFloat(fields[17], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HSS_EC_BCU, _ = strconv.ParseFloat(fields[18], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.EC_VALUE, _ = strconv.ParseFloat(fields[19], 64)
-	}
-}
-
-func (s *STAT_SL1L2) fill_STAT_SL1L2(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen {
-		s.FBAR, _ = strconv.ParseFloat(fields[1], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OBAR, _ = strconv.ParseFloat(fields[2], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FOBAR, _ = strconv.ParseFloat(fields[3], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FFBAR, _ = strconv.ParseFloat(fields[4], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OOBAR, _ = strconv.ParseFloat(fields[5], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.MAE, _ = strconv.ParseFloat(fields[6], 64)
-	}
-}
-
 func (s *TCST_TCDIAG) fill_TCST_TCDIAG(fields []string) {
 	dataLen := len(fields) - 1
 	i := -1
@@ -8327,58 +8382,9 @@ func (s *TCST_TCDIAG) fill_TCST_TCDIAG(fields []string) {
 			}
 		}
 	}
-}
-
-func (s *STAT_ISC) fill_STAT_ISC(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
 	i++
 	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen {
-		s.TILE_DIM, _ = strconv.Atoi(fields[1])
-	}
-	i++
-	if i <= dataLen {
-		s.TILE_XLL, _ = strconv.Atoi(fields[2])
-	}
-	i++
-	if i <= dataLen {
-		s.TILE_YLL, _ = strconv.Atoi(fields[3])
-	}
-	i++
-	if i <= dataLen {
-		s.NSCALE, _ = strconv.Atoi(fields[4])
-	}
-	i++
-	if i <= dataLen {
-		s.ISCALE, _ = strconv.Atoi(fields[5])
-	}
-	i++
-	if i <= dataLen {
-		s.MSE, _ = strconv.ParseFloat(fields[6], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ISC, _ = strconv.ParseFloat(fields[7], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FENERGY2, _ = strconv.ParseFloat(fields[8], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OENERGY2, _ = strconv.ParseFloat(fields[9], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BASER, _ = strconv.ParseFloat(fields[10], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FBIAS, _ = strconv.ParseFloat(fields[11], 64)
+		s.INIT, _ = strconv.Atoi(fields[8])
 	}
 }
 

--- a/pkg/structColumnTypes/structColumnTypes.go
+++ b/pkg/structColumnTypes/structColumnTypes.go
@@ -60,410 +60,6 @@ func SetValueForField(doc *map[string]interface{}, fileType string, term string,
 const DOC_NOT_FOUND = "Document not found:"
 
 // Header struct definitions
-type STAT_VAL1L2_header struct {
-	VERSION        string  `json:"version"`
-	MODEL          string  `json:"model"`
-	DESC           string  `json:"desc"`
-	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
-	FCST_VALID_END int     `json:"fcst_valid_end"`
-	OBS_LEAD       int     `json:"obs_lead"`
-	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
-	OBS_VALID_END  int     `json:"obs_valid_end"`
-	FCST_VAR       string  `json:"fcst_var"`
-	FCST_UNITS     string  `json:"fcst_units"`
-	FCST_LEV       string  `json:"fcst_lev"`
-	OBS_VAR        string  `json:"obs_var"`
-	OBS_UNITS      string  `json:"obs_units"`
-	OBS_LEV        string  `json:"obs_lev"`
-	OBTYPE         string  `json:"obtype"`
-	VX_MASK        string  `json:"vx_mask"`
-	INTERP_MTHD    string  `json:"interp_mthd"`
-	INTERP_PNTS    int     `json:"interp_pnts"`
-	FCST_THRESH    string  `json:"fcst_thresh"`
-	OBS_THRESH     string  `json:"obs_thresh"`
-	COV_THRESH     string  `json:"cov_thresh"`
-	ALPHA          float64 `json:"alpha"`
-	LINE_TYPE      string  `json:"line_type"`
-}
-
-type STAT_MPR_header struct {
-	VERSION        string  `json:"version"`
-	MODEL          string  `json:"model"`
-	DESC           string  `json:"desc"`
-	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
-	FCST_VALID_END int     `json:"fcst_valid_end"`
-	OBS_LEAD       int     `json:"obs_lead"`
-	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
-	OBS_VALID_END  int     `json:"obs_valid_end"`
-	FCST_VAR       string  `json:"fcst_var"`
-	FCST_UNITS     string  `json:"fcst_units"`
-	FCST_LEV       string  `json:"fcst_lev"`
-	OBS_VAR        string  `json:"obs_var"`
-	OBS_UNITS      string  `json:"obs_units"`
-	OBS_LEV        string  `json:"obs_lev"`
-	OBTYPE         string  `json:"obtype"`
-	VX_MASK        string  `json:"vx_mask"`
-	INTERP_MTHD    string  `json:"interp_mthd"`
-	INTERP_PNTS    int     `json:"interp_pnts"`
-	FCST_THRESH    string  `json:"fcst_thresh"`
-	OBS_THRESH     string  `json:"obs_thresh"`
-	COV_THRESH     string  `json:"cov_thresh"`
-	ALPHA          float64 `json:"alpha"`
-	LINE_TYPE      string  `json:"line_type"`
-}
-
-type STAT_GRAD_header struct {
-	VERSION        string  `json:"version"`
-	MODEL          string  `json:"model"`
-	DESC           string  `json:"desc"`
-	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
-	FCST_VALID_END int     `json:"fcst_valid_end"`
-	OBS_LEAD       int     `json:"obs_lead"`
-	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
-	OBS_VALID_END  int     `json:"obs_valid_end"`
-	FCST_VAR       string  `json:"fcst_var"`
-	FCST_UNITS     string  `json:"fcst_units"`
-	FCST_LEV       string  `json:"fcst_lev"`
-	OBS_VAR        string  `json:"obs_var"`
-	OBS_UNITS      string  `json:"obs_units"`
-	OBS_LEV        string  `json:"obs_lev"`
-	OBTYPE         string  `json:"obtype"`
-	VX_MASK        string  `json:"vx_mask"`
-	INTERP_MTHD    string  `json:"interp_mthd"`
-	INTERP_PNTS    int     `json:"interp_pnts"`
-	FCST_THRESH    string  `json:"fcst_thresh"`
-	OBS_THRESH     string  `json:"obs_thresh"`
-	COV_THRESH     string  `json:"cov_thresh"`
-	ALPHA          float64 `json:"alpha"`
-	LINE_TYPE      string  `json:"line_type"`
-}
-
-type STAT_ECLV_header struct {
-	VERSION        string  `json:"version"`
-	MODEL          string  `json:"model"`
-	DESC           string  `json:"desc"`
-	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
-	FCST_VALID_END int     `json:"fcst_valid_end"`
-	OBS_LEAD       int     `json:"obs_lead"`
-	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
-	OBS_VALID_END  int     `json:"obs_valid_end"`
-	FCST_VAR       string  `json:"fcst_var"`
-	FCST_UNITS     string  `json:"fcst_units"`
-	FCST_LEV       string  `json:"fcst_lev"`
-	OBS_VAR        string  `json:"obs_var"`
-	OBS_UNITS      string  `json:"obs_units"`
-	OBS_LEV        string  `json:"obs_lev"`
-	OBTYPE         string  `json:"obtype"`
-	VX_MASK        string  `json:"vx_mask"`
-	INTERP_MTHD    string  `json:"interp_mthd"`
-	INTERP_PNTS    int     `json:"interp_pnts"`
-	FCST_THRESH    string  `json:"fcst_thresh"`
-	OBS_THRESH     string  `json:"obs_thresh"`
-	COV_THRESH     string  `json:"cov_thresh"`
-	ALPHA          float64 `json:"alpha"`
-	LINE_TYPE      string  `json:"line_type"`
-}
-
-type STAT_RHIST_header struct {
-	VERSION        string  `json:"version"`
-	MODEL          string  `json:"model"`
-	DESC           string  `json:"desc"`
-	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
-	FCST_VALID_END int     `json:"fcst_valid_end"`
-	OBS_LEAD       int     `json:"obs_lead"`
-	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
-	OBS_VALID_END  int     `json:"obs_valid_end"`
-	FCST_VAR       string  `json:"fcst_var"`
-	FCST_UNITS     string  `json:"fcst_units"`
-	FCST_LEV       string  `json:"fcst_lev"`
-	OBS_VAR        string  `json:"obs_var"`
-	OBS_UNITS      string  `json:"obs_units"`
-	OBS_LEV        string  `json:"obs_lev"`
-	OBTYPE         string  `json:"obtype"`
-	VX_MASK        string  `json:"vx_mask"`
-	INTERP_MTHD    string  `json:"interp_mthd"`
-	INTERP_PNTS    int     `json:"interp_pnts"`
-	FCST_THRESH    string  `json:"fcst_thresh"`
-	OBS_THRESH     string  `json:"obs_thresh"`
-	COV_THRESH     string  `json:"cov_thresh"`
-	ALPHA          float64 `json:"alpha"`
-	LINE_TYPE      string  `json:"line_type"`
-}
-
-type STAT_SSIDX_header struct {
-	VERSION        string  `json:"version"`
-	MODEL          string  `json:"model"`
-	DESC           string  `json:"desc"`
-	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
-	FCST_VALID_END int     `json:"fcst_valid_end"`
-	OBS_LEAD       int     `json:"obs_lead"`
-	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
-	OBS_VALID_END  int     `json:"obs_valid_end"`
-	FCST_VAR       string  `json:"fcst_var"`
-	FCST_UNITS     string  `json:"fcst_units"`
-	FCST_LEV       string  `json:"fcst_lev"`
-	OBS_VAR        string  `json:"obs_var"`
-	OBS_UNITS      string  `json:"obs_units"`
-	OBS_LEV        string  `json:"obs_lev"`
-	OBTYPE         string  `json:"obtype"`
-	VX_MASK        string  `json:"vx_mask"`
-	INTERP_MTHD    string  `json:"interp_mthd"`
-	INTERP_PNTS    int     `json:"interp_pnts"`
-	FCST_THRESH    string  `json:"fcst_thresh"`
-	OBS_THRESH     string  `json:"obs_thresh"`
-	COV_THRESH     string  `json:"cov_thresh"`
-	ALPHA          float64 `json:"alpha"`
-	LINE_TYPE      string  `json:"line_type"`
-}
-
-type MODE_CTS_header struct {
-	VERSION    string  `json:"version"`
-	MODEL      string  `json:"model"`
-	N_VALID    int     `json:"n_valid"`
-	GRID_RES   float64 `json:"grid_res"`
-	DESC       string  `json:"desc"`
-	FCST_VALID string  `json:"fcst_valid"`
-	FCST_ACCUM string  `json:"fcst_accum"`
-	OBS_LEAD   int     `json:"obs_lead"`
-	OBS_VALID  string  `json:"obs_valid"`
-	OBS_ACCUM  string  `json:"obs_accum"`
-	FCST_RAD   int     `json:"fcst_rad"`
-	FCST_THR   string  `json:"fcst_thr"`
-	OBS_RAD    int     `json:"obs_rad"`
-	OBS_THR    string  `json:"obs_thr"`
-	FCST_VAR   string  `json:"fcst_var"`
-	FCST_UNITS string  `json:"fcst_units"`
-	FCST_LEV   string  `json:"fcst_lev"`
-	OBS_VAR    string  `json:"obs_var"`
-	OBS_UNITS  string  `json:"obs_units"`
-	OBS_LEV    string  `json:"obs_lev"`
-	OBTYPE     string  `json:"obtype"`
-	LINE_TYPE  string  `json:"line_type"`
-}
-
-type MTD_3DPAIR_header struct {
-	VERSION    string `json:"version"`
-	MODEL      string `json:"model"`
-	DESC       string `json:"desc"`
-	FCST_LEAD  int    `json:"fcst_lead"`
-	FCST_VALID string `json:"fcst_valid"`
-	OBS_LEAD   int    `json:"obs_lead"`
-	OBS_VALID  string `json:"obs_valid"`
-	T_DELTA    string `json:"t_delta"`
-	FCST_T_BEG int    `json:"fcst_t_beg"`
-	FCST_T_END int    `json:"fcst_t_end"`
-	FCST_RAD   int    `json:"fcst_rad"`
-	FCST_THR   string `json:"fcst_thr"`
-	OBS_T_BEG  int    `json:"obs_t_beg"`
-	OBS_T_END  int    `json:"obs_t_end"`
-	OBS_RAD    int    `json:"obs_rad"`
-	OBS_THR    string `json:"obs_thr"`
-	FCST_VAR   string `json:"fcst_var"`
-	FCST_UNITS string `json:"fcst_units"`
-	FCST_LEV   string `json:"fcst_lev"`
-	OBS_VAR    string `json:"obs_var"`
-	OBS_UNITS  string `json:"obs_units"`
-	OBS_LEV    string `json:"obs_lev"`
-	LINE_TYPE  string `json:"line_type"`
-}
-
-type STAT_MCTC_header struct {
-	VERSION        string  `json:"version"`
-	MODEL          string  `json:"model"`
-	DESC           string  `json:"desc"`
-	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
-	FCST_VALID_END int     `json:"fcst_valid_end"`
-	OBS_LEAD       int     `json:"obs_lead"`
-	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
-	OBS_VALID_END  int     `json:"obs_valid_end"`
-	FCST_VAR       string  `json:"fcst_var"`
-	FCST_UNITS     string  `json:"fcst_units"`
-	FCST_LEV       string  `json:"fcst_lev"`
-	OBS_VAR        string  `json:"obs_var"`
-	OBS_UNITS      string  `json:"obs_units"`
-	OBS_LEV        string  `json:"obs_lev"`
-	OBTYPE         string  `json:"obtype"`
-	VX_MASK        string  `json:"vx_mask"`
-	INTERP_MTHD    string  `json:"interp_mthd"`
-	INTERP_PNTS    int     `json:"interp_pnts"`
-	FCST_THRESH    string  `json:"fcst_thresh"`
-	OBS_THRESH     string  `json:"obs_thresh"`
-	COV_THRESH     string  `json:"cov_thresh"`
-	ALPHA          float64 `json:"alpha"`
-	LINE_TYPE      string  `json:"line_type"`
-}
-
-type STAT_SEEPS_header struct {
-	VERSION        string  `json:"version"`
-	MODEL          string  `json:"model"`
-	DESC           string  `json:"desc"`
-	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
-	FCST_VALID_END int     `json:"fcst_valid_end"`
-	OBS_LEAD       int     `json:"obs_lead"`
-	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
-	OBS_VALID_END  int     `json:"obs_valid_end"`
-	FCST_VAR       string  `json:"fcst_var"`
-	FCST_UNITS     string  `json:"fcst_units"`
-	FCST_LEV       string  `json:"fcst_lev"`
-	OBS_VAR        string  `json:"obs_var"`
-	OBS_UNITS      string  `json:"obs_units"`
-	OBS_LEV        string  `json:"obs_lev"`
-	OBTYPE         string  `json:"obtype"`
-	VX_MASK        string  `json:"vx_mask"`
-	INTERP_MTHD    string  `json:"interp_mthd"`
-	INTERP_PNTS    int     `json:"interp_pnts"`
-	FCST_THRESH    string  `json:"fcst_thresh"`
-	OBS_THRESH     string  `json:"obs_thresh"`
-	COV_THRESH     string  `json:"cov_thresh"`
-	ALPHA          float64 `json:"alpha"`
-	LINE_TYPE      string  `json:"line_type"`
-}
-
-type STAT_PRC_header struct {
-	VERSION        string  `json:"version"`
-	MODEL          string  `json:"model"`
-	DESC           string  `json:"desc"`
-	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
-	FCST_VALID_END int     `json:"fcst_valid_end"`
-	OBS_LEAD       int     `json:"obs_lead"`
-	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
-	OBS_VALID_END  int     `json:"obs_valid_end"`
-	FCST_VAR       string  `json:"fcst_var"`
-	FCST_UNITS     string  `json:"fcst_units"`
-	FCST_LEV       string  `json:"fcst_lev"`
-	OBS_VAR        string  `json:"obs_var"`
-	OBS_UNITS      string  `json:"obs_units"`
-	OBS_LEV        string  `json:"obs_lev"`
-	OBTYPE         string  `json:"obtype"`
-	VX_MASK        string  `json:"vx_mask"`
-	INTERP_MTHD    string  `json:"interp_mthd"`
-	INTERP_PNTS    int     `json:"interp_pnts"`
-	FCST_THRESH    string  `json:"fcst_thresh"`
-	OBS_THRESH     string  `json:"obs_thresh"`
-	COV_THRESH     string  `json:"cov_thresh"`
-	ALPHA          float64 `json:"alpha"`
-	LINE_TYPE      string  `json:"line_type"`
-}
-
-type STAT_SAL1L2_header struct {
-	VERSION        string  `json:"version"`
-	MODEL          string  `json:"model"`
-	DESC           string  `json:"desc"`
-	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
-	FCST_VALID_END int     `json:"fcst_valid_end"`
-	OBS_LEAD       int     `json:"obs_lead"`
-	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
-	OBS_VALID_END  int     `json:"obs_valid_end"`
-	FCST_VAR       string  `json:"fcst_var"`
-	FCST_UNITS     string  `json:"fcst_units"`
-	FCST_LEV       string  `json:"fcst_lev"`
-	OBS_VAR        string  `json:"obs_var"`
-	OBS_UNITS      string  `json:"obs_units"`
-	OBS_LEV        string  `json:"obs_lev"`
-	OBTYPE         string  `json:"obtype"`
-	VX_MASK        string  `json:"vx_mask"`
-	INTERP_MTHD    string  `json:"interp_mthd"`
-	INTERP_PNTS    int     `json:"interp_pnts"`
-	FCST_THRESH    string  `json:"fcst_thresh"`
-	OBS_THRESH     string  `json:"obs_thresh"`
-	COV_THRESH     string  `json:"cov_thresh"`
-	ALPHA          float64 `json:"alpha"`
-	LINE_TYPE      string  `json:"line_type"`
-}
-
-type STAT_SL1L2_header struct {
-	VERSION        string  `json:"version"`
-	MODEL          string  `json:"model"`
-	DESC           string  `json:"desc"`
-	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
-	FCST_VALID_END int     `json:"fcst_valid_end"`
-	OBS_LEAD       int     `json:"obs_lead"`
-	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
-	OBS_VALID_END  int     `json:"obs_valid_end"`
-	FCST_VAR       string  `json:"fcst_var"`
-	FCST_UNITS     string  `json:"fcst_units"`
-	FCST_LEV       string  `json:"fcst_lev"`
-	OBS_VAR        string  `json:"obs_var"`
-	OBS_UNITS      string  `json:"obs_units"`
-	OBS_LEV        string  `json:"obs_lev"`
-	OBTYPE         string  `json:"obtype"`
-	VX_MASK        string  `json:"vx_mask"`
-	INTERP_MTHD    string  `json:"interp_mthd"`
-	INTERP_PNTS    int     `json:"interp_pnts"`
-	FCST_THRESH    string  `json:"fcst_thresh"`
-	OBS_THRESH     string  `json:"obs_thresh"`
-	COV_THRESH     string  `json:"cov_thresh"`
-	ALPHA          float64 `json:"alpha"`
-	LINE_TYPE      string  `json:"line_type"`
-}
-
-type STAT_VCNT_header struct {
-	VERSION        string  `json:"version"`
-	MODEL          string  `json:"model"`
-	DESC           string  `json:"desc"`
-	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
-	FCST_VALID_END int     `json:"fcst_valid_end"`
-	OBS_LEAD       int     `json:"obs_lead"`
-	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
-	OBS_VALID_END  int     `json:"obs_valid_end"`
-	FCST_VAR       string  `json:"fcst_var"`
-	FCST_UNITS     string  `json:"fcst_units"`
-	FCST_LEV       string  `json:"fcst_lev"`
-	OBS_VAR        string  `json:"obs_var"`
-	OBS_UNITS      string  `json:"obs_units"`
-	OBS_LEV        string  `json:"obs_lev"`
-	OBTYPE         string  `json:"obtype"`
-	VX_MASK        string  `json:"vx_mask"`
-	INTERP_MTHD    string  `json:"interp_mthd"`
-	INTERP_PNTS    int     `json:"interp_pnts"`
-	FCST_THRESH    string  `json:"fcst_thresh"`
-	OBS_THRESH     string  `json:"obs_thresh"`
-	COV_THRESH     string  `json:"cov_thresh"`
-	ALPHA          float64 `json:"alpha"`
-	LINE_TYPE      string  `json:"line_type"`
-}
-
-type MTD_2DSINGLE_header struct {
-	VERSION    string `json:"version"`
-	MODEL      string `json:"model"`
-	DESC       string `json:"desc"`
-	FCST_LEAD  int    `json:"fcst_lead"`
-	FCST_VALID string `json:"fcst_valid"`
-	OBS_LEAD   int    `json:"obs_lead"`
-	OBS_VALID  string `json:"obs_valid"`
-	T_DELTA    string `json:"t_delta"`
-	FCST_T_BEG int    `json:"fcst_t_beg"`
-	FCST_T_END int    `json:"fcst_t_end"`
-	FCST_RAD   int    `json:"fcst_rad"`
-	FCST_THR   string `json:"fcst_thr"`
-	OBS_T_BEG  int    `json:"obs_t_beg"`
-	OBS_T_END  int    `json:"obs_t_end"`
-	OBS_RAD    int    `json:"obs_rad"`
-	OBS_THR    string `json:"obs_thr"`
-	FCST_VAR   string `json:"fcst_var"`
-	FCST_UNITS string `json:"fcst_units"`
-	FCST_LEV   string `json:"fcst_lev"`
-	OBS_VAR    string `json:"obs_var"`
-	OBS_UNITS  string `json:"obs_units"`
-	OBS_LEV    string `json:"obs_lev"`
-	LINE_TYPE  string `json:"line_type"`
-}
-
-type TCST_TCMPR_header struct {
-	VERSION    string `json:"version"`
-	AMODEL     string `json:"amodel"`
-	BMODEL     string `json:"bmodel"`
-	DESC       string `json:"desc"`
-	STORM_ID   string `json:"storm_id"`
-	BASIN      string `json:"basin"`
-	CYCLONE    string `json:"cyclone"`
-	STORM_NAME string `json:"storm_name"`
-	VALID      int    `json:"valid"`
-	INIT_MASK  string `json:"init_mask"`
-	VALID_MASK string `json:"valid_mask"`
-	LINE_TYPE  string `json:"line_type"`
-}
-
 type STAT_CTC_header struct {
 	VERSION        string  `json:"version"`
 	MODEL          string  `json:"model"`
@@ -490,7 +86,7 @@ type STAT_CTC_header struct {
 	LINE_TYPE      string  `json:"line_type"`
 }
 
-type STAT_ORANK_header struct {
+type STAT_FHO_header struct {
 	VERSION        string  `json:"version"`
 	MODEL          string  `json:"model"`
 	DESC           string  `json:"desc"`
@@ -516,7 +112,7 @@ type STAT_ORANK_header struct {
 	LINE_TYPE      string  `json:"line_type"`
 }
 
-type STAT_PJC_header struct {
+type STAT_SEEPS_MPR_header struct {
 	VERSION        string  `json:"version"`
 	MODEL          string  `json:"model"`
 	DESC           string  `json:"desc"`
@@ -542,7 +138,7 @@ type STAT_PJC_header struct {
 	LINE_TYPE      string  `json:"line_type"`
 }
 
-type STAT_PCT_header struct {
+type STAT_RPS_header struct {
 	VERSION        string  `json:"version"`
 	MODEL          string  `json:"model"`
 	DESC           string  `json:"desc"`
@@ -568,7 +164,7 @@ type STAT_PCT_header struct {
 	LINE_TYPE      string  `json:"line_type"`
 }
 
-type STAT_PSTD_header struct {
+type STAT_RELP_header struct {
 	VERSION        string  `json:"version"`
 	MODEL          string  `json:"model"`
 	DESC           string  `json:"desc"`
@@ -646,7 +242,292 @@ type MTD_3DSINGLE_header struct {
 	LINE_TYPE  string `json:"line_type"`
 }
 
-type TCST_TCDIAG_header struct {
+type STAT_CNT_header struct {
+	VERSION        string  `json:"version"`
+	MODEL          string  `json:"model"`
+	DESC           string  `json:"desc"`
+	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
+	FCST_VALID_END int     `json:"fcst_valid_end"`
+	OBS_LEAD       int     `json:"obs_lead"`
+	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
+	OBS_VALID_END  int     `json:"obs_valid_end"`
+	FCST_VAR       string  `json:"fcst_var"`
+	FCST_UNITS     string  `json:"fcst_units"`
+	FCST_LEV       string  `json:"fcst_lev"`
+	OBS_VAR        string  `json:"obs_var"`
+	OBS_UNITS      string  `json:"obs_units"`
+	OBS_LEV        string  `json:"obs_lev"`
+	OBTYPE         string  `json:"obtype"`
+	VX_MASK        string  `json:"vx_mask"`
+	INTERP_MTHD    string  `json:"interp_mthd"`
+	INTERP_PNTS    int     `json:"interp_pnts"`
+	FCST_THRESH    string  `json:"fcst_thresh"`
+	OBS_THRESH     string  `json:"obs_thresh"`
+	COV_THRESH     string  `json:"cov_thresh"`
+	ALPHA          float64 `json:"alpha"`
+	LINE_TYPE      string  `json:"line_type"`
+}
+
+type MTD_3DPAIR_header struct {
+	VERSION    string `json:"version"`
+	MODEL      string `json:"model"`
+	DESC       string `json:"desc"`
+	FCST_LEAD  int    `json:"fcst_lead"`
+	FCST_VALID string `json:"fcst_valid"`
+	OBS_LEAD   int    `json:"obs_lead"`
+	OBS_VALID  string `json:"obs_valid"`
+	T_DELTA    string `json:"t_delta"`
+	FCST_T_BEG int    `json:"fcst_t_beg"`
+	FCST_T_END int    `json:"fcst_t_end"`
+	FCST_RAD   int    `json:"fcst_rad"`
+	FCST_THR   string `json:"fcst_thr"`
+	OBS_T_BEG  int    `json:"obs_t_beg"`
+	OBS_T_END  int    `json:"obs_t_end"`
+	OBS_RAD    int    `json:"obs_rad"`
+	OBS_THR    string `json:"obs_thr"`
+	FCST_VAR   string `json:"fcst_var"`
+	FCST_UNITS string `json:"fcst_units"`
+	FCST_LEV   string `json:"fcst_lev"`
+	OBS_VAR    string `json:"obs_var"`
+	OBS_UNITS  string `json:"obs_units"`
+	OBS_LEV    string `json:"obs_lev"`
+	LINE_TYPE  string `json:"line_type"`
+}
+
+type STAT_GRAD_header struct {
+	VERSION        string  `json:"version"`
+	MODEL          string  `json:"model"`
+	DESC           string  `json:"desc"`
+	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
+	FCST_VALID_END int     `json:"fcst_valid_end"`
+	OBS_LEAD       int     `json:"obs_lead"`
+	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
+	OBS_VALID_END  int     `json:"obs_valid_end"`
+	FCST_VAR       string  `json:"fcst_var"`
+	FCST_UNITS     string  `json:"fcst_units"`
+	FCST_LEV       string  `json:"fcst_lev"`
+	OBS_VAR        string  `json:"obs_var"`
+	OBS_UNITS      string  `json:"obs_units"`
+	OBS_LEV        string  `json:"obs_lev"`
+	OBTYPE         string  `json:"obtype"`
+	VX_MASK        string  `json:"vx_mask"`
+	INTERP_MTHD    string  `json:"interp_mthd"`
+	INTERP_PNTS    int     `json:"interp_pnts"`
+	FCST_THRESH    string  `json:"fcst_thresh"`
+	OBS_THRESH     string  `json:"obs_thresh"`
+	COV_THRESH     string  `json:"cov_thresh"`
+	ALPHA          float64 `json:"alpha"`
+	LINE_TYPE      string  `json:"line_type"`
+}
+
+type STAT_PSTD_header struct {
+	VERSION        string  `json:"version"`
+	MODEL          string  `json:"model"`
+	DESC           string  `json:"desc"`
+	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
+	FCST_VALID_END int     `json:"fcst_valid_end"`
+	OBS_LEAD       int     `json:"obs_lead"`
+	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
+	OBS_VALID_END  int     `json:"obs_valid_end"`
+	FCST_VAR       string  `json:"fcst_var"`
+	FCST_UNITS     string  `json:"fcst_units"`
+	FCST_LEV       string  `json:"fcst_lev"`
+	OBS_VAR        string  `json:"obs_var"`
+	OBS_UNITS      string  `json:"obs_units"`
+	OBS_LEV        string  `json:"obs_lev"`
+	OBTYPE         string  `json:"obtype"`
+	VX_MASK        string  `json:"vx_mask"`
+	INTERP_MTHD    string  `json:"interp_mthd"`
+	INTERP_PNTS    int     `json:"interp_pnts"`
+	FCST_THRESH    string  `json:"fcst_thresh"`
+	OBS_THRESH     string  `json:"obs_thresh"`
+	COV_THRESH     string  `json:"cov_thresh"`
+	ALPHA          float64 `json:"alpha"`
+	LINE_TYPE      string  `json:"line_type"`
+}
+
+type STAT_RHIST_header struct {
+	VERSION        string  `json:"version"`
+	MODEL          string  `json:"model"`
+	DESC           string  `json:"desc"`
+	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
+	FCST_VALID_END int     `json:"fcst_valid_end"`
+	OBS_LEAD       int     `json:"obs_lead"`
+	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
+	OBS_VALID_END  int     `json:"obs_valid_end"`
+	FCST_VAR       string  `json:"fcst_var"`
+	FCST_UNITS     string  `json:"fcst_units"`
+	FCST_LEV       string  `json:"fcst_lev"`
+	OBS_VAR        string  `json:"obs_var"`
+	OBS_UNITS      string  `json:"obs_units"`
+	OBS_LEV        string  `json:"obs_lev"`
+	OBTYPE         string  `json:"obtype"`
+	VX_MASK        string  `json:"vx_mask"`
+	INTERP_MTHD    string  `json:"interp_mthd"`
+	INTERP_PNTS    int     `json:"interp_pnts"`
+	FCST_THRESH    string  `json:"fcst_thresh"`
+	OBS_THRESH     string  `json:"obs_thresh"`
+	COV_THRESH     string  `json:"cov_thresh"`
+	ALPHA          float64 `json:"alpha"`
+	LINE_TYPE      string  `json:"line_type"`
+}
+
+type STAT_GENMPR_header struct {
+	VERSION        string  `json:"version"`
+	MODEL          string  `json:"model"`
+	DESC           string  `json:"desc"`
+	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
+	FCST_VALID_END int     `json:"fcst_valid_end"`
+	OBS_LEAD       int     `json:"obs_lead"`
+	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
+	OBS_VALID_END  int     `json:"obs_valid_end"`
+	FCST_VAR       string  `json:"fcst_var"`
+	FCST_UNITS     string  `json:"fcst_units"`
+	FCST_LEV       string  `json:"fcst_lev"`
+	OBS_VAR        string  `json:"obs_var"`
+	OBS_UNITS      string  `json:"obs_units"`
+	OBS_LEV        string  `json:"obs_lev"`
+	OBTYPE         string  `json:"obtype"`
+	VX_MASK        string  `json:"vx_mask"`
+	INTERP_MTHD    string  `json:"interp_mthd"`
+	INTERP_PNTS    int     `json:"interp_pnts"`
+	FCST_THRESH    string  `json:"fcst_thresh"`
+	OBS_THRESH     string  `json:"obs_thresh"`
+	COV_THRESH     string  `json:"cov_thresh"`
+	ALPHA          float64 `json:"alpha"`
+	LINE_TYPE      string  `json:"line_type"`
+}
+
+type MTD_2DSINGLE_header struct {
+	VERSION    string `json:"version"`
+	MODEL      string `json:"model"`
+	DESC       string `json:"desc"`
+	FCST_LEAD  int    `json:"fcst_lead"`
+	FCST_VALID string `json:"fcst_valid"`
+	OBS_LEAD   int    `json:"obs_lead"`
+	OBS_VALID  string `json:"obs_valid"`
+	T_DELTA    string `json:"t_delta"`
+	FCST_T_BEG int    `json:"fcst_t_beg"`
+	FCST_T_END int    `json:"fcst_t_end"`
+	FCST_RAD   int    `json:"fcst_rad"`
+	FCST_THR   string `json:"fcst_thr"`
+	OBS_T_BEG  int    `json:"obs_t_beg"`
+	OBS_T_END  int    `json:"obs_t_end"`
+	OBS_RAD    int    `json:"obs_rad"`
+	OBS_THR    string `json:"obs_thr"`
+	FCST_VAR   string `json:"fcst_var"`
+	FCST_UNITS string `json:"fcst_units"`
+	FCST_LEV   string `json:"fcst_lev"`
+	OBS_VAR    string `json:"obs_var"`
+	OBS_UNITS  string `json:"obs_units"`
+	OBS_LEV    string `json:"obs_lev"`
+	LINE_TYPE  string `json:"line_type"`
+}
+
+type STAT_NBRCTC_header struct {
+	VERSION        string  `json:"version"`
+	MODEL          string  `json:"model"`
+	DESC           string  `json:"desc"`
+	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
+	FCST_VALID_END int     `json:"fcst_valid_end"`
+	OBS_LEAD       int     `json:"obs_lead"`
+	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
+	OBS_VALID_END  int     `json:"obs_valid_end"`
+	FCST_VAR       string  `json:"fcst_var"`
+	FCST_UNITS     string  `json:"fcst_units"`
+	FCST_LEV       string  `json:"fcst_lev"`
+	OBS_VAR        string  `json:"obs_var"`
+	OBS_UNITS      string  `json:"obs_units"`
+	OBS_LEV        string  `json:"obs_lev"`
+	OBTYPE         string  `json:"obtype"`
+	VX_MASK        string  `json:"vx_mask"`
+	INTERP_MTHD    string  `json:"interp_mthd"`
+	INTERP_PNTS    int     `json:"interp_pnts"`
+	FCST_THRESH    string  `json:"fcst_thresh"`
+	OBS_THRESH     string  `json:"obs_thresh"`
+	COV_THRESH     string  `json:"cov_thresh"`
+	ALPHA          float64 `json:"alpha"`
+	LINE_TYPE      string  `json:"line_type"`
+}
+
+type STAT_SAL1L2_header struct {
+	VERSION        string  `json:"version"`
+	MODEL          string  `json:"model"`
+	DESC           string  `json:"desc"`
+	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
+	FCST_VALID_END int     `json:"fcst_valid_end"`
+	OBS_LEAD       int     `json:"obs_lead"`
+	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
+	OBS_VALID_END  int     `json:"obs_valid_end"`
+	FCST_VAR       string  `json:"fcst_var"`
+	FCST_UNITS     string  `json:"fcst_units"`
+	FCST_LEV       string  `json:"fcst_lev"`
+	OBS_VAR        string  `json:"obs_var"`
+	OBS_UNITS      string  `json:"obs_units"`
+	OBS_LEV        string  `json:"obs_lev"`
+	OBTYPE         string  `json:"obtype"`
+	VX_MASK        string  `json:"vx_mask"`
+	INTERP_MTHD    string  `json:"interp_mthd"`
+	INTERP_PNTS    int     `json:"interp_pnts"`
+	FCST_THRESH    string  `json:"fcst_thresh"`
+	OBS_THRESH     string  `json:"obs_thresh"`
+	COV_THRESH     string  `json:"cov_thresh"`
+	ALPHA          float64 `json:"alpha"`
+	LINE_TYPE      string  `json:"line_type"`
+}
+
+type STAT_VAL1L2_header struct {
+	VERSION        string  `json:"version"`
+	MODEL          string  `json:"model"`
+	DESC           string  `json:"desc"`
+	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
+	FCST_VALID_END int     `json:"fcst_valid_end"`
+	OBS_LEAD       int     `json:"obs_lead"`
+	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
+	OBS_VALID_END  int     `json:"obs_valid_end"`
+	FCST_VAR       string  `json:"fcst_var"`
+	FCST_UNITS     string  `json:"fcst_units"`
+	FCST_LEV       string  `json:"fcst_lev"`
+	OBS_VAR        string  `json:"obs_var"`
+	OBS_UNITS      string  `json:"obs_units"`
+	OBS_LEV        string  `json:"obs_lev"`
+	OBTYPE         string  `json:"obtype"`
+	VX_MASK        string  `json:"vx_mask"`
+	INTERP_MTHD    string  `json:"interp_mthd"`
+	INTERP_PNTS    int     `json:"interp_pnts"`
+	FCST_THRESH    string  `json:"fcst_thresh"`
+	OBS_THRESH     string  `json:"obs_thresh"`
+	COV_THRESH     string  `json:"cov_thresh"`
+	ALPHA          float64 `json:"alpha"`
+	LINE_TYPE      string  `json:"line_type"`
+}
+
+type MODE_CTS_header struct {
+	VERSION    string  `json:"version"`
+	MODEL      string  `json:"model"`
+	N_VALID    int     `json:"n_valid"`
+	GRID_RES   float64 `json:"grid_res"`
+	DESC       string  `json:"desc"`
+	FCST_VALID string  `json:"fcst_valid"`
+	FCST_ACCUM string  `json:"fcst_accum"`
+	OBS_LEAD   int     `json:"obs_lead"`
+	OBS_VALID  string  `json:"obs_valid"`
+	OBS_ACCUM  string  `json:"obs_accum"`
+	FCST_RAD   int     `json:"fcst_rad"`
+	FCST_THR   string  `json:"fcst_thr"`
+	OBS_RAD    int     `json:"obs_rad"`
+	OBS_THR    string  `json:"obs_thr"`
+	FCST_VAR   string  `json:"fcst_var"`
+	FCST_UNITS string  `json:"fcst_units"`
+	FCST_LEV   string  `json:"fcst_lev"`
+	OBS_VAR    string  `json:"obs_var"`
+	OBS_UNITS  string  `json:"obs_units"`
+	OBS_LEV    string  `json:"obs_lev"`
+	OBTYPE     string  `json:"obtype"`
+	LINE_TYPE  string  `json:"line_type"`
+}
+
+type TCST_PROBRIRW_header struct {
 	VERSION    string `json:"version"`
 	AMODEL     string `json:"amodel"`
 	BMODEL     string `json:"bmodel"`
@@ -661,7 +542,136 @@ type TCST_TCDIAG_header struct {
 	LINE_TYPE  string `json:"line_type"`
 }
 
-type STAT_CTS_header struct {
+type STAT_NBRCTS_header struct {
+	VERSION        string  `json:"version"`
+	MODEL          string  `json:"model"`
+	DESC           string  `json:"desc"`
+	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
+	FCST_VALID_END int     `json:"fcst_valid_end"`
+	OBS_LEAD       int     `json:"obs_lead"`
+	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
+	OBS_VALID_END  int     `json:"obs_valid_end"`
+	FCST_VAR       string  `json:"fcst_var"`
+	FCST_UNITS     string  `json:"fcst_units"`
+	FCST_LEV       string  `json:"fcst_lev"`
+	OBS_VAR        string  `json:"obs_var"`
+	OBS_UNITS      string  `json:"obs_units"`
+	OBS_LEV        string  `json:"obs_lev"`
+	OBTYPE         string  `json:"obtype"`
+	VX_MASK        string  `json:"vx_mask"`
+	INTERP_MTHD    string  `json:"interp_mthd"`
+	INTERP_PNTS    int     `json:"interp_pnts"`
+	FCST_THRESH    string  `json:"fcst_thresh"`
+	OBS_THRESH     string  `json:"obs_thresh"`
+	COV_THRESH     string  `json:"cov_thresh"`
+	ALPHA          float64 `json:"alpha"`
+	LINE_TYPE      string  `json:"line_type"`
+}
+
+type STAT_PCT_header struct {
+	VERSION        string  `json:"version"`
+	MODEL          string  `json:"model"`
+	DESC           string  `json:"desc"`
+	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
+	FCST_VALID_END int     `json:"fcst_valid_end"`
+	OBS_LEAD       int     `json:"obs_lead"`
+	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
+	OBS_VALID_END  int     `json:"obs_valid_end"`
+	FCST_VAR       string  `json:"fcst_var"`
+	FCST_UNITS     string  `json:"fcst_units"`
+	FCST_LEV       string  `json:"fcst_lev"`
+	OBS_VAR        string  `json:"obs_var"`
+	OBS_UNITS      string  `json:"obs_units"`
+	OBS_LEV        string  `json:"obs_lev"`
+	OBTYPE         string  `json:"obtype"`
+	VX_MASK        string  `json:"vx_mask"`
+	INTERP_MTHD    string  `json:"interp_mthd"`
+	INTERP_PNTS    int     `json:"interp_pnts"`
+	FCST_THRESH    string  `json:"fcst_thresh"`
+	OBS_THRESH     string  `json:"obs_thresh"`
+	COV_THRESH     string  `json:"cov_thresh"`
+	ALPHA          float64 `json:"alpha"`
+	LINE_TYPE      string  `json:"line_type"`
+}
+
+type STAT_PJC_header struct {
+	VERSION        string  `json:"version"`
+	MODEL          string  `json:"model"`
+	DESC           string  `json:"desc"`
+	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
+	FCST_VALID_END int     `json:"fcst_valid_end"`
+	OBS_LEAD       int     `json:"obs_lead"`
+	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
+	OBS_VALID_END  int     `json:"obs_valid_end"`
+	FCST_VAR       string  `json:"fcst_var"`
+	FCST_UNITS     string  `json:"fcst_units"`
+	FCST_LEV       string  `json:"fcst_lev"`
+	OBS_VAR        string  `json:"obs_var"`
+	OBS_UNITS      string  `json:"obs_units"`
+	OBS_LEV        string  `json:"obs_lev"`
+	OBTYPE         string  `json:"obtype"`
+	VX_MASK        string  `json:"vx_mask"`
+	INTERP_MTHD    string  `json:"interp_mthd"`
+	INTERP_PNTS    int     `json:"interp_pnts"`
+	FCST_THRESH    string  `json:"fcst_thresh"`
+	OBS_THRESH     string  `json:"obs_thresh"`
+	COV_THRESH     string  `json:"cov_thresh"`
+	ALPHA          float64 `json:"alpha"`
+	LINE_TYPE      string  `json:"line_type"`
+}
+
+type STAT_VCNT_header struct {
+	VERSION        string  `json:"version"`
+	MODEL          string  `json:"model"`
+	DESC           string  `json:"desc"`
+	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
+	FCST_VALID_END int     `json:"fcst_valid_end"`
+	OBS_LEAD       int     `json:"obs_lead"`
+	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
+	OBS_VALID_END  int     `json:"obs_valid_end"`
+	FCST_VAR       string  `json:"fcst_var"`
+	FCST_UNITS     string  `json:"fcst_units"`
+	FCST_LEV       string  `json:"fcst_lev"`
+	OBS_VAR        string  `json:"obs_var"`
+	OBS_UNITS      string  `json:"obs_units"`
+	OBS_LEV        string  `json:"obs_lev"`
+	OBTYPE         string  `json:"obtype"`
+	VX_MASK        string  `json:"vx_mask"`
+	INTERP_MTHD    string  `json:"interp_mthd"`
+	INTERP_PNTS    int     `json:"interp_pnts"`
+	FCST_THRESH    string  `json:"fcst_thresh"`
+	OBS_THRESH     string  `json:"obs_thresh"`
+	COV_THRESH     string  `json:"cov_thresh"`
+	ALPHA          float64 `json:"alpha"`
+	LINE_TYPE      string  `json:"line_type"`
+}
+
+type MODE_OBJ_header struct {
+	VERSION    string  `json:"version"`
+	MODEL      string  `json:"model"`
+	N_VALID    int     `json:"n_valid"`
+	GRID_RES   float64 `json:"grid_res"`
+	DESC       string  `json:"desc"`
+	FCST_VALID string  `json:"fcst_valid"`
+	FCST_ACCUM string  `json:"fcst_accum"`
+	OBS_LEAD   int     `json:"obs_lead"`
+	OBS_VALID  string  `json:"obs_valid"`
+	OBS_ACCUM  string  `json:"obs_accum"`
+	FCST_RAD   int     `json:"fcst_rad"`
+	FCST_THR   string  `json:"fcst_thr"`
+	OBS_RAD    int     `json:"obs_rad"`
+	OBS_THR    string  `json:"obs_thr"`
+	FCST_VAR   string  `json:"fcst_var"`
+	FCST_UNITS string  `json:"fcst_units"`
+	FCST_LEV   string  `json:"fcst_lev"`
+	OBS_VAR    string  `json:"obs_var"`
+	OBS_UNITS  string  `json:"obs_units"`
+	OBS_LEV    string  `json:"obs_lev"`
+	OBTYPE     string  `json:"obtype"`
+	LINE_TYPE  string  `json:"line_type"`
+}
+
+type STAT_ORANK_header struct {
 	VERSION        string  `json:"version"`
 	MODEL          string  `json:"model"`
 	DESC           string  `json:"desc"`
@@ -739,22 +749,7 @@ type STAT_DMAP_header struct {
 	LINE_TYPE      string  `json:"line_type"`
 }
 
-type TCST_PROBRIRW_header struct {
-	VERSION    string `json:"version"`
-	AMODEL     string `json:"amodel"`
-	BMODEL     string `json:"bmodel"`
-	DESC       string `json:"desc"`
-	STORM_ID   string `json:"storm_id"`
-	BASIN      string `json:"basin"`
-	CYCLONE    string `json:"cyclone"`
-	STORM_NAME string `json:"storm_name"`
-	VALID      int    `json:"valid"`
-	INIT_MASK  string `json:"init_mask"`
-	VALID_MASK string `json:"valid_mask"`
-	LINE_TYPE  string `json:"line_type"`
-}
-
-type STAT_RPS_header struct {
+type STAT_PRC_header struct {
 	VERSION        string  `json:"version"`
 	MODEL          string  `json:"model"`
 	DESC           string  `json:"desc"`
@@ -780,7 +775,37 @@ type STAT_RPS_header struct {
 	LINE_TYPE      string  `json:"line_type"`
 }
 
-type STAT_GENMPR_header struct {
+type TCST_TCMPR_header struct {
+	VERSION    string `json:"version"`
+	AMODEL     string `json:"amodel"`
+	BMODEL     string `json:"bmodel"`
+	DESC       string `json:"desc"`
+	STORM_ID   string `json:"storm_id"`
+	BASIN      string `json:"basin"`
+	CYCLONE    string `json:"cyclone"`
+	STORM_NAME string `json:"storm_name"`
+	VALID      int    `json:"valid"`
+	INIT_MASK  string `json:"init_mask"`
+	VALID_MASK string `json:"valid_mask"`
+	LINE_TYPE  string `json:"line_type"`
+}
+
+type TCST_TCDIAG_header struct {
+	VERSION    string `json:"version"`
+	AMODEL     string `json:"amodel"`
+	BMODEL     string `json:"bmodel"`
+	DESC       string `json:"desc"`
+	STORM_ID   string `json:"storm_id"`
+	BASIN      string `json:"basin"`
+	CYCLONE    string `json:"cyclone"`
+	STORM_NAME string `json:"storm_name"`
+	VALID      int    `json:"valid"`
+	INIT_MASK  string `json:"init_mask"`
+	VALID_MASK string `json:"valid_mask"`
+	LINE_TYPE  string `json:"line_type"`
+}
+
+type STAT_MPR_header struct {
 	VERSION        string  `json:"version"`
 	MODEL          string  `json:"model"`
 	DESC           string  `json:"desc"`
@@ -832,84 +857,7 @@ type STAT_ISC_header struct {
 	LINE_TYPE      string  `json:"line_type"`
 }
 
-type STAT_SEEPS_MPR_header struct {
-	VERSION        string  `json:"version"`
-	MODEL          string  `json:"model"`
-	DESC           string  `json:"desc"`
-	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
-	FCST_VALID_END int     `json:"fcst_valid_end"`
-	OBS_LEAD       int     `json:"obs_lead"`
-	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
-	OBS_VALID_END  int     `json:"obs_valid_end"`
-	FCST_VAR       string  `json:"fcst_var"`
-	FCST_UNITS     string  `json:"fcst_units"`
-	FCST_LEV       string  `json:"fcst_lev"`
-	OBS_VAR        string  `json:"obs_var"`
-	OBS_UNITS      string  `json:"obs_units"`
-	OBS_LEV        string  `json:"obs_lev"`
-	OBTYPE         string  `json:"obtype"`
-	VX_MASK        string  `json:"vx_mask"`
-	INTERP_MTHD    string  `json:"interp_mthd"`
-	INTERP_PNTS    int     `json:"interp_pnts"`
-	FCST_THRESH    string  `json:"fcst_thresh"`
-	OBS_THRESH     string  `json:"obs_thresh"`
-	COV_THRESH     string  `json:"cov_thresh"`
-	ALPHA          float64 `json:"alpha"`
-	LINE_TYPE      string  `json:"line_type"`
-}
-
-type STAT_NBRCTC_header struct {
-	VERSION        string  `json:"version"`
-	MODEL          string  `json:"model"`
-	DESC           string  `json:"desc"`
-	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
-	FCST_VALID_END int     `json:"fcst_valid_end"`
-	OBS_LEAD       int     `json:"obs_lead"`
-	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
-	OBS_VALID_END  int     `json:"obs_valid_end"`
-	FCST_VAR       string  `json:"fcst_var"`
-	FCST_UNITS     string  `json:"fcst_units"`
-	FCST_LEV       string  `json:"fcst_lev"`
-	OBS_VAR        string  `json:"obs_var"`
-	OBS_UNITS      string  `json:"obs_units"`
-	OBS_LEV        string  `json:"obs_lev"`
-	OBTYPE         string  `json:"obtype"`
-	VX_MASK        string  `json:"vx_mask"`
-	INTERP_MTHD    string  `json:"interp_mthd"`
-	INTERP_PNTS    int     `json:"interp_pnts"`
-	FCST_THRESH    string  `json:"fcst_thresh"`
-	OBS_THRESH     string  `json:"obs_thresh"`
-	COV_THRESH     string  `json:"cov_thresh"`
-	ALPHA          float64 `json:"alpha"`
-	LINE_TYPE      string  `json:"line_type"`
-}
-
-type MODE_OBJ_header struct {
-	VERSION    string  `json:"version"`
-	MODEL      string  `json:"model"`
-	N_VALID    int     `json:"n_valid"`
-	GRID_RES   float64 `json:"grid_res"`
-	DESC       string  `json:"desc"`
-	FCST_VALID string  `json:"fcst_valid"`
-	FCST_ACCUM string  `json:"fcst_accum"`
-	OBS_LEAD   int     `json:"obs_lead"`
-	OBS_VALID  string  `json:"obs_valid"`
-	OBS_ACCUM  string  `json:"obs_accum"`
-	FCST_RAD   int     `json:"fcst_rad"`
-	FCST_THR   string  `json:"fcst_thr"`
-	OBS_RAD    int     `json:"obs_rad"`
-	OBS_THR    string  `json:"obs_thr"`
-	FCST_VAR   string  `json:"fcst_var"`
-	FCST_UNITS string  `json:"fcst_units"`
-	FCST_LEV   string  `json:"fcst_lev"`
-	OBS_VAR    string  `json:"obs_var"`
-	OBS_UNITS  string  `json:"obs_units"`
-	OBS_LEV    string  `json:"obs_lev"`
-	OBTYPE     string  `json:"obtype"`
-	LINE_TYPE  string  `json:"line_type"`
-}
-
-type STAT_FHO_header struct {
+type STAT_SEEPS_header struct {
 	VERSION        string  `json:"version"`
 	MODEL          string  `json:"model"`
 	DESC           string  `json:"desc"`
@@ -961,7 +909,7 @@ type STAT_PHIST_header struct {
 	LINE_TYPE      string  `json:"line_type"`
 }
 
-type STAT_RELP_header struct {
+type STAT_SSIDX_header struct {
 	VERSION        string  `json:"version"`
 	MODEL          string  `json:"model"`
 	DESC           string  `json:"desc"`
@@ -987,59 +935,7 @@ type STAT_RELP_header struct {
 	LINE_TYPE      string  `json:"line_type"`
 }
 
-type STAT_ECNT_header struct {
-	VERSION        string  `json:"version"`
-	MODEL          string  `json:"model"`
-	DESC           string  `json:"desc"`
-	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
-	FCST_VALID_END int     `json:"fcst_valid_end"`
-	OBS_LEAD       int     `json:"obs_lead"`
-	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
-	OBS_VALID_END  int     `json:"obs_valid_end"`
-	FCST_VAR       string  `json:"fcst_var"`
-	FCST_UNITS     string  `json:"fcst_units"`
-	FCST_LEV       string  `json:"fcst_lev"`
-	OBS_VAR        string  `json:"obs_var"`
-	OBS_UNITS      string  `json:"obs_units"`
-	OBS_LEV        string  `json:"obs_lev"`
-	OBTYPE         string  `json:"obtype"`
-	VX_MASK        string  `json:"vx_mask"`
-	INTERP_MTHD    string  `json:"interp_mthd"`
-	INTERP_PNTS    int     `json:"interp_pnts"`
-	FCST_THRESH    string  `json:"fcst_thresh"`
-	OBS_THRESH     string  `json:"obs_thresh"`
-	COV_THRESH     string  `json:"cov_thresh"`
-	ALPHA          float64 `json:"alpha"`
-	LINE_TYPE      string  `json:"line_type"`
-}
-
-type STAT_SSVAR_header struct {
-	VERSION        string  `json:"version"`
-	MODEL          string  `json:"model"`
-	DESC           string  `json:"desc"`
-	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
-	FCST_VALID_END int     `json:"fcst_valid_end"`
-	OBS_LEAD       int     `json:"obs_lead"`
-	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
-	OBS_VALID_END  int     `json:"obs_valid_end"`
-	FCST_VAR       string  `json:"fcst_var"`
-	FCST_UNITS     string  `json:"fcst_units"`
-	FCST_LEV       string  `json:"fcst_lev"`
-	OBS_VAR        string  `json:"obs_var"`
-	OBS_UNITS      string  `json:"obs_units"`
-	OBS_LEV        string  `json:"obs_lev"`
-	OBTYPE         string  `json:"obtype"`
-	VX_MASK        string  `json:"vx_mask"`
-	INTERP_MTHD    string  `json:"interp_mthd"`
-	INTERP_PNTS    int     `json:"interp_pnts"`
-	FCST_THRESH    string  `json:"fcst_thresh"`
-	OBS_THRESH     string  `json:"obs_thresh"`
-	COV_THRESH     string  `json:"cov_thresh"`
-	ALPHA          float64 `json:"alpha"`
-	LINE_TYPE      string  `json:"line_type"`
-}
-
-type STAT_CNT_header struct {
+type STAT_CTS_header struct {
 	VERSION        string  `json:"version"`
 	MODEL          string  `json:"model"`
 	DESC           string  `json:"desc"`
@@ -1091,7 +987,111 @@ type STAT_MCTS_header struct {
 	LINE_TYPE      string  `json:"line_type"`
 }
 
-type STAT_NBRCTS_header struct {
+type STAT_ECLV_header struct {
+	VERSION        string  `json:"version"`
+	MODEL          string  `json:"model"`
+	DESC           string  `json:"desc"`
+	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
+	FCST_VALID_END int     `json:"fcst_valid_end"`
+	OBS_LEAD       int     `json:"obs_lead"`
+	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
+	OBS_VALID_END  int     `json:"obs_valid_end"`
+	FCST_VAR       string  `json:"fcst_var"`
+	FCST_UNITS     string  `json:"fcst_units"`
+	FCST_LEV       string  `json:"fcst_lev"`
+	OBS_VAR        string  `json:"obs_var"`
+	OBS_UNITS      string  `json:"obs_units"`
+	OBS_LEV        string  `json:"obs_lev"`
+	OBTYPE         string  `json:"obtype"`
+	VX_MASK        string  `json:"vx_mask"`
+	INTERP_MTHD    string  `json:"interp_mthd"`
+	INTERP_PNTS    int     `json:"interp_pnts"`
+	FCST_THRESH    string  `json:"fcst_thresh"`
+	OBS_THRESH     string  `json:"obs_thresh"`
+	COV_THRESH     string  `json:"cov_thresh"`
+	ALPHA          float64 `json:"alpha"`
+	LINE_TYPE      string  `json:"line_type"`
+}
+
+type STAT_ECNT_header struct {
+	VERSION        string  `json:"version"`
+	MODEL          string  `json:"model"`
+	DESC           string  `json:"desc"`
+	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
+	FCST_VALID_END int     `json:"fcst_valid_end"`
+	OBS_LEAD       int     `json:"obs_lead"`
+	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
+	OBS_VALID_END  int     `json:"obs_valid_end"`
+	FCST_VAR       string  `json:"fcst_var"`
+	FCST_UNITS     string  `json:"fcst_units"`
+	FCST_LEV       string  `json:"fcst_lev"`
+	OBS_VAR        string  `json:"obs_var"`
+	OBS_UNITS      string  `json:"obs_units"`
+	OBS_LEV        string  `json:"obs_lev"`
+	OBTYPE         string  `json:"obtype"`
+	VX_MASK        string  `json:"vx_mask"`
+	INTERP_MTHD    string  `json:"interp_mthd"`
+	INTERP_PNTS    int     `json:"interp_pnts"`
+	FCST_THRESH    string  `json:"fcst_thresh"`
+	OBS_THRESH     string  `json:"obs_thresh"`
+	COV_THRESH     string  `json:"cov_thresh"`
+	ALPHA          float64 `json:"alpha"`
+	LINE_TYPE      string  `json:"line_type"`
+}
+
+type STAT_SL1L2_header struct {
+	VERSION        string  `json:"version"`
+	MODEL          string  `json:"model"`
+	DESC           string  `json:"desc"`
+	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
+	FCST_VALID_END int     `json:"fcst_valid_end"`
+	OBS_LEAD       int     `json:"obs_lead"`
+	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
+	OBS_VALID_END  int     `json:"obs_valid_end"`
+	FCST_VAR       string  `json:"fcst_var"`
+	FCST_UNITS     string  `json:"fcst_units"`
+	FCST_LEV       string  `json:"fcst_lev"`
+	OBS_VAR        string  `json:"obs_var"`
+	OBS_UNITS      string  `json:"obs_units"`
+	OBS_LEV        string  `json:"obs_lev"`
+	OBTYPE         string  `json:"obtype"`
+	VX_MASK        string  `json:"vx_mask"`
+	INTERP_MTHD    string  `json:"interp_mthd"`
+	INTERP_PNTS    int     `json:"interp_pnts"`
+	FCST_THRESH    string  `json:"fcst_thresh"`
+	OBS_THRESH     string  `json:"obs_thresh"`
+	COV_THRESH     string  `json:"cov_thresh"`
+	ALPHA          float64 `json:"alpha"`
+	LINE_TYPE      string  `json:"line_type"`
+}
+
+type STAT_SSVAR_header struct {
+	VERSION        string  `json:"version"`
+	MODEL          string  `json:"model"`
+	DESC           string  `json:"desc"`
+	FCST_VALID_BEG int     `json:"fcst_valid_beg"`
+	FCST_VALID_END int     `json:"fcst_valid_end"`
+	OBS_LEAD       int     `json:"obs_lead"`
+	OBS_VALID_BEG  int     `json:"obs_valid_beg"`
+	OBS_VALID_END  int     `json:"obs_valid_end"`
+	FCST_VAR       string  `json:"fcst_var"`
+	FCST_UNITS     string  `json:"fcst_units"`
+	FCST_LEV       string  `json:"fcst_lev"`
+	OBS_VAR        string  `json:"obs_var"`
+	OBS_UNITS      string  `json:"obs_units"`
+	OBS_LEV        string  `json:"obs_lev"`
+	OBTYPE         string  `json:"obtype"`
+	VX_MASK        string  `json:"vx_mask"`
+	INTERP_MTHD    string  `json:"interp_mthd"`
+	INTERP_PNTS    int     `json:"interp_pnts"`
+	FCST_THRESH    string  `json:"fcst_thresh"`
+	OBS_THRESH     string  `json:"obs_thresh"`
+	COV_THRESH     string  `json:"cov_thresh"`
+	ALPHA          float64 `json:"alpha"`
+	LINE_TYPE      string  `json:"line_type"`
+}
+
+type STAT_MCTC_header struct {
 	VERSION        string  `json:"version"`
 	MODEL          string  `json:"model"`
 	DESC           string  `json:"desc"`
@@ -1118,6 +1118,162 @@ type STAT_NBRCTS_header struct {
 }
 
 // fillHeader functions
+func (s *STAT_MCTS) fill_STAT_MCTS_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *STAT_NBRCNT) fill_STAT_NBRCNT_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *STAT_DMAP) fill_STAT_DMAP_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
 func (s *STAT_PRC) fill_STAT_PRC_Header(fields []string, doc *map[string]interface{}) {
 	dataLen := len(fields)
 	i := -1
@@ -1170,7 +1326,7 @@ func (s *STAT_PRC) fill_STAT_PRC_Header(fields []string, doc *map[string]interfa
 	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
 }
 
-func (s *STAT_ECLV) fill_STAT_ECLV_Header(fields []string, doc *map[string]interface{}) {
+func (s *STAT_GENMPR) fill_STAT_GENMPR_Header(fields []string, doc *map[string]interface{}) {
 	dataLen := len(fields)
 	i := -1
 	// fill the met fields leaving out "" and NA values
@@ -1220,367 +1376,6 @@ func (s *STAT_ECLV) fill_STAT_ECLV_Header(fields []string, doc *map[string]inter
 	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
 	i++
 	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *STAT_RHIST) fill_STAT_RHIST_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *STAT_CTC) fill_STAT_CTC_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *STAT_NBRCTS) fill_STAT_NBRCTS_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *STAT_GRAD) fill_STAT_GRAD_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *STAT_ORANK) fill_STAT_ORANK_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *STAT_SL1L2) fill_STAT_SL1L2_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *MODE_CTS) fill_MODE_CTS_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "MODE", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "MODE", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "MODE", "N_VALID", i, dataLen, fields, 2, "int")
-	i++
-	SetValueForField(doc, "MODE", "GRID_RES", i, dataLen, fields, 3, "float64")
-	i++
-	SetValueForField(doc, "MODE", "DESC", i, dataLen, fields, 4, "string")
-	i++
-	SetValueForField(doc, "MODE", "FCST_VALID", i, dataLen, fields, 6, "string")
-	i++
-	SetValueForField(doc, "MODE", "FCST_ACCUM", i, dataLen, fields, 7, "string")
-	i++
-	SetValueForField(doc, "MODE", "OBS_LEAD", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "MODE", "OBS_VALID", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "MODE", "OBS_ACCUM", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "MODE", "FCST_RAD", i, dataLen, fields, 11, "int")
-	i++
-	SetValueForField(doc, "MODE", "FCST_THR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "MODE", "OBS_RAD", i, dataLen, fields, 13, "int")
-	i++
-	SetValueForField(doc, "MODE", "OBS_THR", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "MODE", "FCST_VAR", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "MODE", "FCST_UNITS", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "MODE", "FCST_LEV", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "MODE", "OBS_VAR", i, dataLen, fields, 18, "string")
-	i++
-	SetValueForField(doc, "MODE", "OBS_UNITS", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "MODE", "OBS_LEV", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "MODE", "OBTYPE", i, dataLen, fields, 21, "string")
-	(*doc)["LINE_TYPE"] = "MODE_CTS"
 }
 
 func (s *STAT_CNT) fill_STAT_CNT_Header(fields []string, doc *map[string]interface{}) {
@@ -1635,504 +1430,7 @@ func (s *STAT_CNT) fill_STAT_CNT_Header(fields []string, doc *map[string]interfa
 	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
 }
 
-func (s *MTD_2DSINGLE) fill_MTD_2DSINGLE_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "MTD", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "MTD", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "MTD", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "MTD", "FCST_LEAD", i, dataLen, fields, 3, "int")
-	i++
-	SetValueForField(doc, "MTD", "FCST_VALID", i, dataLen, fields, 4, "string")
-	i++
-	SetValueForField(doc, "MTD", "OBS_LEAD", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "MTD", "OBS_VALID", i, dataLen, fields, 6, "string")
-	i++
-	SetValueForField(doc, "MTD", "T_DELTA", i, dataLen, fields, 7, "string")
-	i++
-	SetValueForField(doc, "MTD", "FCST_T_BEG", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "MTD", "FCST_T_END", i, dataLen, fields, 9, "int")
-	i++
-	SetValueForField(doc, "MTD", "FCST_RAD", i, dataLen, fields, 10, "int")
-	i++
-	SetValueForField(doc, "MTD", "FCST_THR", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "MTD", "OBS_T_BEG", i, dataLen, fields, 12, "int")
-	i++
-	SetValueForField(doc, "MTD", "OBS_T_END", i, dataLen, fields, 13, "int")
-	i++
-	SetValueForField(doc, "MTD", "OBS_RAD", i, dataLen, fields, 14, "int")
-	i++
-	SetValueForField(doc, "MTD", "OBS_THR", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "MTD", "FCST_VAR", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "MTD", "FCST_UNITS", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "MTD", "FCST_LEV", i, dataLen, fields, 18, "string")
-	i++
-	SetValueForField(doc, "MTD", "OBS_VAR", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "MTD", "OBS_UNITS", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "MTD", "OBS_LEV", i, dataLen, fields, 21, "string")
-	(*doc)["LINE_TYPE"] = "MTD_2DSINGLE"
-}
-
-func (s *STAT_MCTC) fill_STAT_MCTC_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *STAT_SAL1L2) fill_STAT_SAL1L2_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *STAT_VCNT) fill_STAT_VCNT_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *TCST_TCDIAG) fill_TCST_TCDIAG_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "TCST", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "TCST", "AMODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "TCST", "BMODEL", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "TCST", "DESC", i, dataLen, fields, 3, "string")
-	i++
-	SetValueForField(doc, "TCST", "STORM_ID", i, dataLen, fields, 4, "string")
-	i++
-	SetValueForField(doc, "TCST", "BASIN", i, dataLen, fields, 5, "string")
-	i++
-	SetValueForField(doc, "TCST", "CYCLONE", i, dataLen, fields, 6, "string")
-	i++
-	SetValueForField(doc, "TCST", "STORM_NAME", i, dataLen, fields, 7, "string")
-	i++
-	SetValueForField(doc, "TCST", "VALID", i, dataLen, fields, 10, "int")
-	i++
-	SetValueForField(doc, "TCST", "INIT_MASK", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "TCST", "VALID_MASK", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "TCST", "LINE_TYPE", i, dataLen, fields, 13, "string")
-}
-
-func (s *STAT_CTS) fill_STAT_CTS_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *STAT_MCTS) fill_STAT_MCTS_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *STAT_MPR) fill_STAT_MPR_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *STAT_SEEPS) fill_STAT_SEEPS_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *STAT_NBRCTC) fill_STAT_NBRCTC_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *STAT_PSTD) fill_STAT_PSTD_Header(fields []string, doc *map[string]interface{}) {
+func (s *STAT_PCT) fill_STAT_PCT_Header(fields []string, doc *map[string]interface{}) {
 	dataLen := len(fields)
 	i := -1
 	// fill the met fields leaving out "" and NA values
@@ -2288,160 +1586,7 @@ func (s *STAT_SSVAR) fill_STAT_SSVAR_Header(fields []string, doc *map[string]int
 	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
 }
 
-func (s *STAT_VAL1L2) fill_STAT_VAL1L2_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *STAT_VL1L2) fill_STAT_VL1L2_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *MODE_OBJ) fill_MODE_OBJ_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "MODE", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "MODE", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "MODE", "N_VALID", i, dataLen, fields, 2, "int")
-	i++
-	SetValueForField(doc, "MODE", "GRID_RES", i, dataLen, fields, 3, "float64")
-	i++
-	SetValueForField(doc, "MODE", "DESC", i, dataLen, fields, 4, "string")
-	i++
-	SetValueForField(doc, "MODE", "FCST_VALID", i, dataLen, fields, 6, "string")
-	i++
-	SetValueForField(doc, "MODE", "FCST_ACCUM", i, dataLen, fields, 7, "string")
-	i++
-	SetValueForField(doc, "MODE", "OBS_LEAD", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "MODE", "OBS_VALID", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "MODE", "OBS_ACCUM", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "MODE", "FCST_RAD", i, dataLen, fields, 11, "int")
-	i++
-	SetValueForField(doc, "MODE", "FCST_THR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "MODE", "OBS_RAD", i, dataLen, fields, 13, "int")
-	i++
-	SetValueForField(doc, "MODE", "OBS_THR", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "MODE", "FCST_VAR", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "MODE", "FCST_UNITS", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "MODE", "FCST_LEV", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "MODE", "OBS_VAR", i, dataLen, fields, 18, "string")
-	i++
-	SetValueForField(doc, "MODE", "OBS_UNITS", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "MODE", "OBS_LEV", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "MODE", "OBTYPE", i, dataLen, fields, 21, "string")
-	(*doc)["LINE_TYPE"] = "MODE_OBJ"
-}
-
-func (s *MTD_3DSINGLE) fill_MTD_3DSINGLE_Header(fields []string, doc *map[string]interface{}) {
+func (s *MTD_2DSINGLE) fill_MTD_2DSINGLE_Header(fields []string, doc *map[string]interface{}) {
 	dataLen := len(fields)
 	i := -1
 	// fill the met fields leaving out "" and NA values
@@ -2489,327 +1634,7 @@ func (s *MTD_3DSINGLE) fill_MTD_3DSINGLE_Header(fields []string, doc *map[string
 	SetValueForField(doc, "MTD", "OBS_UNITS", i, dataLen, fields, 20, "string")
 	i++
 	SetValueForField(doc, "MTD", "OBS_LEV", i, dataLen, fields, 21, "string")
-	(*doc)["LINE_TYPE"] = "MTD_3DSINGLE"
-}
-
-func (s *STAT_NBRCNT) fill_STAT_NBRCNT_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *STAT_RPS) fill_STAT_RPS_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *STAT_GENMPR) fill_STAT_GENMPR_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *TCST_PROBRIRW) fill_TCST_PROBRIRW_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "TCST", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "TCST", "AMODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "TCST", "BMODEL", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "TCST", "DESC", i, dataLen, fields, 3, "string")
-	i++
-	SetValueForField(doc, "TCST", "STORM_ID", i, dataLen, fields, 4, "string")
-	i++
-	SetValueForField(doc, "TCST", "BASIN", i, dataLen, fields, 5, "string")
-	i++
-	SetValueForField(doc, "TCST", "CYCLONE", i, dataLen, fields, 6, "string")
-	i++
-	SetValueForField(doc, "TCST", "STORM_NAME", i, dataLen, fields, 7, "string")
-	i++
-	SetValueForField(doc, "TCST", "VALID", i, dataLen, fields, 10, "int")
-	i++
-	SetValueForField(doc, "TCST", "INIT_MASK", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "TCST", "VALID_MASK", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "TCST", "LINE_TYPE", i, dataLen, fields, 13, "string")
-}
-
-func (s *STAT_SEEPS_MPR) fill_STAT_SEEPS_MPR_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *STAT_SSIDX) fill_STAT_SSIDX_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
-	i++
-	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
-	i++
-	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
-	i++
-	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
-	i++
-	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
-	i++
-	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
-	i++
-	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
-	i++
-	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
-	i++
-	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
-}
-
-func (s *TCST_TCMPR) fill_TCST_TCMPR_Header(fields []string, doc *map[string]interface{}) {
-	dataLen := len(fields)
-	i := -1
-	// fill the met fields leaving out "" and NA values
-	i++
-	SetValueForField(doc, "TCST", "VERSION", i, dataLen, fields, 0, "string")
-	i++
-	SetValueForField(doc, "TCST", "AMODEL", i, dataLen, fields, 1, "string")
-	i++
-	SetValueForField(doc, "TCST", "BMODEL", i, dataLen, fields, 2, "string")
-	i++
-	SetValueForField(doc, "TCST", "DESC", i, dataLen, fields, 3, "string")
-	i++
-	SetValueForField(doc, "TCST", "STORM_ID", i, dataLen, fields, 4, "string")
-	i++
-	SetValueForField(doc, "TCST", "BASIN", i, dataLen, fields, 5, "string")
-	i++
-	SetValueForField(doc, "TCST", "CYCLONE", i, dataLen, fields, 6, "string")
-	i++
-	SetValueForField(doc, "TCST", "STORM_NAME", i, dataLen, fields, 7, "string")
-	i++
-	SetValueForField(doc, "TCST", "VALID", i, dataLen, fields, 10, "int")
-	i++
-	SetValueForField(doc, "TCST", "INIT_MASK", i, dataLen, fields, 11, "string")
-	i++
-	SetValueForField(doc, "TCST", "VALID_MASK", i, dataLen, fields, 12, "string")
-	i++
-	SetValueForField(doc, "TCST", "LINE_TYPE", i, dataLen, fields, 13, "string")
+	(*doc)["LINE_TYPE"] = "MTD_2DSINGLE"
 }
 
 func (s *STAT_FHO) fill_STAT_FHO_Header(fields []string, doc *map[string]interface{}) {
@@ -2916,7 +1741,7 @@ func (s *STAT_ISC) fill_STAT_ISC_Header(fields []string, doc *map[string]interfa
 	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
 }
 
-func (s *STAT_DMAP) fill_STAT_DMAP_Header(fields []string, doc *map[string]interface{}) {
+func (s *STAT_NBRCTS) fill_STAT_NBRCTS_Header(fields []string, doc *map[string]interface{}) {
 	dataLen := len(fields)
 	i := -1
 	// fill the met fields leaving out "" and NA values
@@ -2968,7 +1793,377 @@ func (s *STAT_DMAP) fill_STAT_DMAP_Header(fields []string, doc *map[string]inter
 	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
 }
 
-func (s *STAT_PCT) fill_STAT_PCT_Header(fields []string, doc *map[string]interface{}) {
+func (s *STAT_VL1L2) fill_STAT_VL1L2_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *TCST_TCMPR) fill_TCST_TCMPR_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "TCST", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "TCST", "AMODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "TCST", "BMODEL", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "TCST", "DESC", i, dataLen, fields, 3, "string")
+	i++
+	SetValueForField(doc, "TCST", "STORM_ID", i, dataLen, fields, 4, "string")
+	i++
+	SetValueForField(doc, "TCST", "BASIN", i, dataLen, fields, 5, "string")
+	i++
+	SetValueForField(doc, "TCST", "CYCLONE", i, dataLen, fields, 6, "string")
+	i++
+	SetValueForField(doc, "TCST", "STORM_NAME", i, dataLen, fields, 7, "string")
+	i++
+	SetValueForField(doc, "TCST", "VALID", i, dataLen, fields, 10, "int")
+	i++
+	SetValueForField(doc, "TCST", "INIT_MASK", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "TCST", "VALID_MASK", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "TCST", "LINE_TYPE", i, dataLen, fields, 13, "string")
+}
+
+func (s *TCST_TCDIAG) fill_TCST_TCDIAG_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "TCST", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "TCST", "AMODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "TCST", "BMODEL", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "TCST", "DESC", i, dataLen, fields, 3, "string")
+	i++
+	SetValueForField(doc, "TCST", "STORM_ID", i, dataLen, fields, 4, "string")
+	i++
+	SetValueForField(doc, "TCST", "BASIN", i, dataLen, fields, 5, "string")
+	i++
+	SetValueForField(doc, "TCST", "CYCLONE", i, dataLen, fields, 6, "string")
+	i++
+	SetValueForField(doc, "TCST", "STORM_NAME", i, dataLen, fields, 7, "string")
+	i++
+	SetValueForField(doc, "TCST", "VALID", i, dataLen, fields, 10, "int")
+	i++
+	SetValueForField(doc, "TCST", "INIT_MASK", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "TCST", "VALID_MASK", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "TCST", "LINE_TYPE", i, dataLen, fields, 13, "string")
+}
+
+func (s *STAT_SEEPS) fill_STAT_SEEPS_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *STAT_NBRCTC) fill_STAT_NBRCTC_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *STAT_SSIDX) fill_STAT_SSIDX_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *MTD_3DSINGLE) fill_MTD_3DSINGLE_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "MTD", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "MTD", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "MTD", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "MTD", "FCST_LEAD", i, dataLen, fields, 3, "int")
+	i++
+	SetValueForField(doc, "MTD", "FCST_VALID", i, dataLen, fields, 4, "string")
+	i++
+	SetValueForField(doc, "MTD", "OBS_LEAD", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "MTD", "OBS_VALID", i, dataLen, fields, 6, "string")
+	i++
+	SetValueForField(doc, "MTD", "T_DELTA", i, dataLen, fields, 7, "string")
+	i++
+	SetValueForField(doc, "MTD", "FCST_T_BEG", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "MTD", "FCST_T_END", i, dataLen, fields, 9, "int")
+	i++
+	SetValueForField(doc, "MTD", "FCST_RAD", i, dataLen, fields, 10, "int")
+	i++
+	SetValueForField(doc, "MTD", "FCST_THR", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "MTD", "OBS_T_BEG", i, dataLen, fields, 12, "int")
+	i++
+	SetValueForField(doc, "MTD", "OBS_T_END", i, dataLen, fields, 13, "int")
+	i++
+	SetValueForField(doc, "MTD", "OBS_RAD", i, dataLen, fields, 14, "int")
+	i++
+	SetValueForField(doc, "MTD", "OBS_THR", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "MTD", "FCST_VAR", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "MTD", "FCST_UNITS", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "MTD", "FCST_LEV", i, dataLen, fields, 18, "string")
+	i++
+	SetValueForField(doc, "MTD", "OBS_VAR", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "MTD", "OBS_UNITS", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "MTD", "OBS_LEV", i, dataLen, fields, 21, "string")
+	(*doc)["LINE_TYPE"] = "MTD_3DSINGLE"
+}
+
+func (s *MTD_3DPAIR) fill_MTD_3DPAIR_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "MTD", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "MTD", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "MTD", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "MTD", "FCST_LEAD", i, dataLen, fields, 3, "int")
+	i++
+	SetValueForField(doc, "MTD", "FCST_VALID", i, dataLen, fields, 4, "string")
+	i++
+	SetValueForField(doc, "MTD", "OBS_LEAD", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "MTD", "OBS_VALID", i, dataLen, fields, 6, "string")
+	i++
+	SetValueForField(doc, "MTD", "T_DELTA", i, dataLen, fields, 7, "string")
+	i++
+	SetValueForField(doc, "MTD", "FCST_T_BEG", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "MTD", "FCST_T_END", i, dataLen, fields, 9, "int")
+	i++
+	SetValueForField(doc, "MTD", "FCST_RAD", i, dataLen, fields, 10, "int")
+	i++
+	SetValueForField(doc, "MTD", "FCST_THR", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "MTD", "OBS_T_BEG", i, dataLen, fields, 12, "int")
+	i++
+	SetValueForField(doc, "MTD", "OBS_T_END", i, dataLen, fields, 13, "int")
+	i++
+	SetValueForField(doc, "MTD", "OBS_RAD", i, dataLen, fields, 14, "int")
+	i++
+	SetValueForField(doc, "MTD", "OBS_THR", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "MTD", "FCST_VAR", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "MTD", "FCST_UNITS", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "MTD", "FCST_LEV", i, dataLen, fields, 18, "string")
+	i++
+	SetValueForField(doc, "MTD", "OBS_VAR", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "MTD", "OBS_UNITS", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "MTD", "OBS_LEV", i, dataLen, fields, 21, "string")
+	(*doc)["LINE_TYPE"] = "MTD_3DPAIR"
+}
+
+func (s *STAT_CTC) fill_STAT_CTC_Header(fields []string, doc *map[string]interface{}) {
 	dataLen := len(fields)
 	i := -1
 	// fill the met fields leaving out "" and NA values
@@ -3176,74 +2371,863 @@ func (s *STAT_RELP) fill_STAT_RELP_Header(fields []string, doc *map[string]inter
 	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
 }
 
-func (s *MTD_3DPAIR) fill_MTD_3DPAIR_Header(fields []string, doc *map[string]interface{}) {
+func (s *STAT_SL1L2) fill_STAT_SL1L2_Header(fields []string, doc *map[string]interface{}) {
 	dataLen := len(fields)
 	i := -1
 	// fill the met fields leaving out "" and NA values
 	i++
-	SetValueForField(doc, "MTD", "VERSION", i, dataLen, fields, 0, "string")
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
 	i++
-	SetValueForField(doc, "MTD", "MODEL", i, dataLen, fields, 1, "string")
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
 	i++
-	SetValueForField(doc, "MTD", "DESC", i, dataLen, fields, 2, "string")
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
 	i++
-	SetValueForField(doc, "MTD", "FCST_LEAD", i, dataLen, fields, 3, "int")
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
 	i++
-	SetValueForField(doc, "MTD", "FCST_VALID", i, dataLen, fields, 4, "string")
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
 	i++
-	SetValueForField(doc, "MTD", "OBS_LEAD", i, dataLen, fields, 5, "int")
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
 	i++
-	SetValueForField(doc, "MTD", "OBS_VALID", i, dataLen, fields, 6, "string")
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
 	i++
-	SetValueForField(doc, "MTD", "T_DELTA", i, dataLen, fields, 7, "string")
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
 	i++
-	SetValueForField(doc, "MTD", "FCST_T_BEG", i, dataLen, fields, 8, "int")
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
 	i++
-	SetValueForField(doc, "MTD", "FCST_T_END", i, dataLen, fields, 9, "int")
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
 	i++
-	SetValueForField(doc, "MTD", "FCST_RAD", i, dataLen, fields, 10, "int")
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
 	i++
-	SetValueForField(doc, "MTD", "FCST_THR", i, dataLen, fields, 11, "string")
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
 	i++
-	SetValueForField(doc, "MTD", "OBS_T_BEG", i, dataLen, fields, 12, "int")
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
 	i++
-	SetValueForField(doc, "MTD", "OBS_T_END", i, dataLen, fields, 13, "int")
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
 	i++
-	SetValueForField(doc, "MTD", "OBS_RAD", i, dataLen, fields, 14, "int")
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
 	i++
-	SetValueForField(doc, "MTD", "OBS_THR", i, dataLen, fields, 15, "string")
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
 	i++
-	SetValueForField(doc, "MTD", "FCST_VAR", i, dataLen, fields, 16, "string")
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
 	i++
-	SetValueForField(doc, "MTD", "FCST_UNITS", i, dataLen, fields, 17, "string")
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
 	i++
-	SetValueForField(doc, "MTD", "FCST_LEV", i, dataLen, fields, 18, "string")
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
 	i++
-	SetValueForField(doc, "MTD", "OBS_VAR", i, dataLen, fields, 19, "string")
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
 	i++
-	SetValueForField(doc, "MTD", "OBS_UNITS", i, dataLen, fields, 20, "string")
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
 	i++
-	SetValueForField(doc, "MTD", "OBS_LEV", i, dataLen, fields, 21, "string")
-	(*doc)["LINE_TYPE"] = "MTD_3DPAIR"
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *STAT_GRAD) fill_STAT_GRAD_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *STAT_ECLV) fill_STAT_ECLV_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *STAT_RHIST) fill_STAT_RHIST_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *STAT_VCNT) fill_STAT_VCNT_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *MODE_CTS) fill_MODE_CTS_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "MODE", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "MODE", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "MODE", "N_VALID", i, dataLen, fields, 2, "int")
+	i++
+	SetValueForField(doc, "MODE", "GRID_RES", i, dataLen, fields, 3, "float64")
+	i++
+	SetValueForField(doc, "MODE", "DESC", i, dataLen, fields, 4, "string")
+	i++
+	SetValueForField(doc, "MODE", "FCST_VALID", i, dataLen, fields, 6, "string")
+	i++
+	SetValueForField(doc, "MODE", "FCST_ACCUM", i, dataLen, fields, 7, "string")
+	i++
+	SetValueForField(doc, "MODE", "OBS_LEAD", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "MODE", "OBS_VALID", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "MODE", "OBS_ACCUM", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "MODE", "FCST_RAD", i, dataLen, fields, 11, "int")
+	i++
+	SetValueForField(doc, "MODE", "FCST_THR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "MODE", "OBS_RAD", i, dataLen, fields, 13, "int")
+	i++
+	SetValueForField(doc, "MODE", "OBS_THR", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "MODE", "FCST_VAR", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "MODE", "FCST_UNITS", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "MODE", "FCST_LEV", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "MODE", "OBS_VAR", i, dataLen, fields, 18, "string")
+	i++
+	SetValueForField(doc, "MODE", "OBS_UNITS", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "MODE", "OBS_LEV", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "MODE", "OBTYPE", i, dataLen, fields, 21, "string")
+	(*doc)["LINE_TYPE"] = "MODE_CTS"
+}
+
+func (s *STAT_CTS) fill_STAT_CTS_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *STAT_MCTC) fill_STAT_MCTC_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *STAT_MPR) fill_STAT_MPR_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *STAT_SEEPS_MPR) fill_STAT_SEEPS_MPR_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *STAT_PSTD) fill_STAT_PSTD_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *STAT_VAL1L2) fill_STAT_VAL1L2_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *STAT_ORANK) fill_STAT_ORANK_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *STAT_RPS) fill_STAT_RPS_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *STAT_SAL1L2) fill_STAT_SAL1L2_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "STAT", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "STAT", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "STAT", "DESC", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_BEG", i, dataLen, fields, 4, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VALID_END", i, dataLen, fields, 5, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEAD", i, dataLen, fields, 6, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_BEG", i, dataLen, fields, 7, "int")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VALID_END", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_VAR", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_UNITS", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "STAT", "FCST_LEV", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_VAR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_UNITS", i, dataLen, fields, 13, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_LEV", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBTYPE", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "STAT", "VX_MASK", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_MTHD", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "STAT", "INTERP_PNTS", i, dataLen, fields, 18, "int")
+	i++
+	SetValueForField(doc, "STAT", "FCST_THRESH", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "STAT", "OBS_THRESH", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "STAT", "COV_THRESH", i, dataLen, fields, 21, "string")
+	i++
+	SetValueForField(doc, "STAT", "ALPHA", i, dataLen, fields, 22, "float64")
+	i++
+	SetValueForField(doc, "STAT", "LINE_TYPE", i, dataLen, fields, 23, "string")
+}
+
+func (s *MODE_OBJ) fill_MODE_OBJ_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "MODE", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "MODE", "MODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "MODE", "N_VALID", i, dataLen, fields, 2, "int")
+	i++
+	SetValueForField(doc, "MODE", "GRID_RES", i, dataLen, fields, 3, "float64")
+	i++
+	SetValueForField(doc, "MODE", "DESC", i, dataLen, fields, 4, "string")
+	i++
+	SetValueForField(doc, "MODE", "FCST_VALID", i, dataLen, fields, 6, "string")
+	i++
+	SetValueForField(doc, "MODE", "FCST_ACCUM", i, dataLen, fields, 7, "string")
+	i++
+	SetValueForField(doc, "MODE", "OBS_LEAD", i, dataLen, fields, 8, "int")
+	i++
+	SetValueForField(doc, "MODE", "OBS_VALID", i, dataLen, fields, 9, "string")
+	i++
+	SetValueForField(doc, "MODE", "OBS_ACCUM", i, dataLen, fields, 10, "string")
+	i++
+	SetValueForField(doc, "MODE", "FCST_RAD", i, dataLen, fields, 11, "int")
+	i++
+	SetValueForField(doc, "MODE", "FCST_THR", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "MODE", "OBS_RAD", i, dataLen, fields, 13, "int")
+	i++
+	SetValueForField(doc, "MODE", "OBS_THR", i, dataLen, fields, 14, "string")
+	i++
+	SetValueForField(doc, "MODE", "FCST_VAR", i, dataLen, fields, 15, "string")
+	i++
+	SetValueForField(doc, "MODE", "FCST_UNITS", i, dataLen, fields, 16, "string")
+	i++
+	SetValueForField(doc, "MODE", "FCST_LEV", i, dataLen, fields, 17, "string")
+	i++
+	SetValueForField(doc, "MODE", "OBS_VAR", i, dataLen, fields, 18, "string")
+	i++
+	SetValueForField(doc, "MODE", "OBS_UNITS", i, dataLen, fields, 19, "string")
+	i++
+	SetValueForField(doc, "MODE", "OBS_LEV", i, dataLen, fields, 20, "string")
+	i++
+	SetValueForField(doc, "MODE", "OBTYPE", i, dataLen, fields, 21, "string")
+	(*doc)["LINE_TYPE"] = "MODE_OBJ"
+}
+
+func (s *TCST_PROBRIRW) fill_TCST_PROBRIRW_Header(fields []string, doc *map[string]interface{}) {
+	dataLen := len(fields)
+	i := -1
+	// fill the met fields leaving out "" and NA values
+	i++
+	SetValueForField(doc, "TCST", "VERSION", i, dataLen, fields, 0, "string")
+	i++
+	SetValueForField(doc, "TCST", "AMODEL", i, dataLen, fields, 1, "string")
+	i++
+	SetValueForField(doc, "TCST", "BMODEL", i, dataLen, fields, 2, "string")
+	i++
+	SetValueForField(doc, "TCST", "DESC", i, dataLen, fields, 3, "string")
+	i++
+	SetValueForField(doc, "TCST", "STORM_ID", i, dataLen, fields, 4, "string")
+	i++
+	SetValueForField(doc, "TCST", "BASIN", i, dataLen, fields, 5, "string")
+	i++
+	SetValueForField(doc, "TCST", "CYCLONE", i, dataLen, fields, 6, "string")
+	i++
+	SetValueForField(doc, "TCST", "STORM_NAME", i, dataLen, fields, 7, "string")
+	i++
+	SetValueForField(doc, "TCST", "VALID", i, dataLen, fields, 10, "int")
+	i++
+	SetValueForField(doc, "TCST", "INIT_MASK", i, dataLen, fields, 11, "string")
+	i++
+	SetValueForField(doc, "TCST", "VALID_MASK", i, dataLen, fields, 12, "string")
+	i++
+	SetValueForField(doc, "TCST", "LINE_TYPE", i, dataLen, fields, 13, "string")
 }
 
 //line data struct definitions
-type STAT_SEEPS_MPR struct {
-	OBS_SID  string  `json:"obs_sid"`
-	OBS_LAT  float64 `json:"obs_lat"`
-	OBS_LON  float64 `json:"obs_lon"`
-	FCST     float64 `json:"fcst"`
-	OBS      float64 `json:"obs"`
-	OBS_QC   string  `json:"obs_qc"`
-	FCST_CAT int     `json:"fcst_cat"`
-	OBS_CAT  int     `json:"obs_cat"`
-	P1       float64 `json:"p1"`
-	P2       float64 `json:"p2"`
-	T1       float64 `json:"t1"`
-	T2       float64 `json:"t2"`
-	SEEPS    float64 `json:"seeps"`
-}
-
 type STAT_ORANK struct {
 	TOTAL            int                    `json:"total"`
 	INDEX            int                    `json:"index"`
@@ -3269,153 +3253,22 @@ type STAT_ORANK struct {
 	FCST_CLIMO_STDEV float64                `json:"fcst_climo_stdev"`
 }
 
-type STAT_RELP struct {
-	TOTAL int                    `json:"total"`
-	ENS   map[string]interface{} `json:"ens"`
-}
-
-type STAT_SSVAR struct {
-	TOTAL       int     `json:"total"`
-	N_BIN       int     `json:"n_bin"`
-	BIN_I       int     `json:"bin_i"`
-	BIN_N       int     `json:"bin_n"`
-	VAR_MIN     float64 `json:"var_min"`
-	VAR_MAX     float64 `json:"var_max"`
-	VAR_MEAN    float64 `json:"var_mean"`
-	FBAR        float64 `json:"fbar"`
-	OBAR        float64 `json:"obar"`
-	FOBAR       float64 `json:"fobar"`
-	FFBAR       float64 `json:"ffbar"`
-	OOBAR       float64 `json:"oobar"`
-	FBAR_NCL    float64 `json:"fbar_ncl"`
-	FBAR_NCU    float64 `json:"fbar_ncu"`
-	FSTDEV      float64 `json:"fstdev"`
-	FSTDEV_NCL  float64 `json:"fstdev_ncl"`
-	FSTDEV_NCU  float64 `json:"fstdev_ncu"`
-	OBAR_NCL    float64 `json:"obar_ncl"`
-	OBAR_NCU    float64 `json:"obar_ncu"`
-	OSTDEV      float64 `json:"ostdev"`
-	OSTDEV_NCL  float64 `json:"ostdev_ncl"`
-	OSTDEV_NCU  float64 `json:"ostdev_ncu"`
-	PR_CORR     float64 `json:"pr_corr"`
-	PR_CORR_NCL float64 `json:"pr_corr_ncl"`
-	PR_CORR_NCU float64 `json:"pr_corr_ncu"`
-	ME          float64 `json:"me"`
-	ME_NCL      float64 `json:"me_ncl"`
-	ME_NCU      float64 `json:"me_ncu"`
-	ESTDEV      float64 `json:"estdev"`
-	ESTDEV_NCL  float64 `json:"estdev_ncl"`
-	ESTDEV_NCU  float64 `json:"estdev_ncu"`
-	MBIAS       float64 `json:"mbias"`
-	MSE         float64 `json:"mse"`
-	BCMSE       float64 `json:"bcmse"`
-	RMSE        float64 `json:"rmse"`
-}
-
-type STAT_SSIDX struct {
-	FCST_MODEL string  `json:"fcst_model"`
-	REF_MODEL  string  `json:"ref_model"`
-	N_INIT     int     `json:"n_init"`
-	N_TERM     int     `json:"n_term"`
-	N_VLD      int     `json:"n_vld"`
-	SS_INDEX   float64 `json:"ss_index"`
-}
-
-type STAT_MPR struct {
-	TOTAL            int     `json:"total"`
-	INDEX            int     `json:"index"`
-	OBS_SID          string  `json:"obs_sid"`
-	OBS_LAT          float64 `json:"obs_lat"`
-	OBS_LON          float64 `json:"obs_lon"`
-	OBS_LVL          float64 `json:"obs_lvl"`
-	OBS_ELV          float64 `json:"obs_elv"`
-	FCST             float64 `json:"fcst"`
-	OBS              float64 `json:"obs"`
-	OBS_QC           string  `json:"obs_qc"`
-	OBS_CLIMO_MEAN   float64 `json:"obs_climo_mean"`
-	OBS_CLIMO_STDEV  float64 `json:"obs_climo_stdev"`
-	OBS_CLIMO_CDF    float64 `json:"obs_climo_cdf"`
-	FCST_CLIMO_MEAN  float64 `json:"fcst_climo_mean"`
-	FCST_CLIMO_STDEV float64 `json:"fcst_climo_stdev"`
-}
-
-type STAT_NBRCTC struct {
-	TOTAL int     `json:"total"`
-	FY_OY float64 `json:"fy_oy"`
-	FY_ON float64 `json:"fy_on"`
-	FN_OY float64 `json:"fn_oy"`
-	FN_ON float64 `json:"fn_on"`
-}
-
-type STAT_ISC struct {
-	TOTAL    int     `json:"total"`
-	TILE_DIM int     `json:"tile_dim"`
-	TILE_XLL int     `json:"tile_xll"`
-	TILE_YLL int     `json:"tile_yll"`
-	NSCALE   int     `json:"nscale"`
-	ISCALE   int     `json:"iscale"`
-	MSE      float64 `json:"mse"`
-	ISC      float64 `json:"isc"`
-	FENERGY2 float64 `json:"fenergy2"`
-	OENERGY2 float64 `json:"oenergy2"`
-	BASER    float64 `json:"baser"`
-	FBIAS    float64 `json:"fbias"`
-}
-
-type STAT_VL1L2 struct {
-	TOTAL       int     `json:"total"`
-	UFBAR       float64 `json:"ufbar"`
-	VFBAR       float64 `json:"vfbar"`
-	UOBAR       float64 `json:"uobar"`
-	VOBAR       float64 `json:"vobar"`
-	UVFOBAR     float64 `json:"uvfobar"`
-	UVFFBAR     float64 `json:"uvffbar"`
-	UVOOBAR     float64 `json:"uvoobar"`
-	F_SPEED_BAR float64 `json:"f_speed_bar"`
-	O_SPEED_BAR float64 `json:"o_speed_bar"`
-	TOTAL_DIR   float64 `json:"total_dir"`
-	DIR_ME      float64 `json:"dir_me"`
-	DIR_MAE     float64 `json:"dir_mae"`
-	DIR_MSE     float64 `json:"dir_mse"`
-}
-
-type MODE_OBJ struct {
-	OBJECT_ID                  string  `json:"object_id"`
-	OBJECT_CAT                 string  `json:"object_cat"`
-	CENTROID_X                 float64 `json:"centroid_x"`
-	CENTROID_Y                 float64 `json:"centroid_y"`
-	CENTROID_LAT               float64 `json:"centroid_lat"`
-	CENTROID_LON               float64 `json:"centroid_lon"`
-	AXIS_ANG                   float64 `json:"axis_ang"`
-	LENGTH                     float64 `json:"length"`
-	WIDTH                      float64 `json:"width"`
-	AREA                       int     `json:"area"`
-	AREA_THRESH                int     `json:"area_thresh"`
-	CURVATURE                  float64 `json:"curvature"`
-	CURVATURE_X                float64 `json:"curvature_x"`
-	CURVATURE_Y                float64 `json:"curvature_y"`
-	COMPLEXITY                 float64 `json:"complexity"`
-	INTENSITY_10               float64 `json:"intensity_10"`
-	INTENSITY_25               float64 `json:"intensity_25"`
-	INTENSITY_50               float64 `json:"intensity_50"`
-	INTENSITY_75               float64 `json:"intensity_75"`
-	INTENSITY_90               float64 `json:"intensity_90"`
-	INTENSITY_USER             float64 `json:"intensity_user"`
-	INTENSITY_SUM              float64 `json:"intensity_sum"`
-	CENTROID_DIST              float64 `json:"centroid_dist"`
-	BOUNDARY_DIST              float64 `json:"boundary_dist"`
-	CONVEX_HULL_DIST           float64 `json:"convex_hull_dist"`
-	ANGLE_DIFF                 float64 `json:"angle_diff"`
-	ASPECT_DIFF                float64 `json:"aspect_diff"`
-	AREA_RATIO                 float64 `json:"area_ratio"`
-	INTERSECTION_AREA          float64 `json:"intersection_area"`
-	UNION_AREA                 float64 `json:"union_area"`
-	SYMMETRIC_DIFF             float64 `json:"symmetric_diff"`
-	INTERSECTION_OVER_AREA     float64 `json:"intersection_over_area"`
-	CURVATURE_RATIO            float64 `json:"curvature_ratio"`
-	COMPLEXITY_RATIO           float64 `json:"complexity_ratio"`
-	PERCENTILE_INTENSITY_RATIO float64 `json:"percentile_intensity_ratio"`
-	INTEREST                   float64 `json:"interest"`
+type MTD_2DSINGLE struct {
+	OBJECT_ID      string  `json:"object_id"`
+	OBJECT_CAT     string  `json:"object_cat"`
+	TIME_INDEX     int     `json:"time_index"`
+	AREA           int     `json:"area"`
+	CENTROID_X     float64 `json:"centroid_x"`
+	CENTROID_Y     float64 `json:"centroid_y"`
+	CENTROID_LAT   float64 `json:"centroid_lat"`
+	CENTROID_LON   float64 `json:"centroid_lon"`
+	AXIS_ANG       float64 `json:"axis_ang"`
+	INTENSITY_10   float64 `json:"intensity_10"`
+	INTENSITY_25   float64 `json:"intensity_25"`
+	INTENSITY_50   float64 `json:"intensity_50"`
+	INTENSITY_75   float64 `json:"intensity_75"`
+	INTENSITY_90   float64 `json:"intensity_90"`
+	INTENSITY_USER float64 `json:"intensity_user"`
 }
 
 type TCST_PROBRIRW struct {
@@ -3443,16 +3296,6 @@ type TCST_PROBRIRW struct {
 	INIT        int                    `json:"init"`
 }
 
-type STAT_SL1L2 struct {
-	TOTAL int     `json:"total"`
-	FBAR  float64 `json:"fbar"`
-	OBAR  float64 `json:"obar"`
-	FOBAR float64 `json:"fobar"`
-	FFBAR float64 `json:"ffbar"`
-	OOBAR float64 `json:"oobar"`
-	MAE   float64 `json:"mae"`
-}
-
 type STAT_MCTS struct {
 	TOTAL      int     `json:"total"`
 	N_CAT      int     `json:"n_cat"`
@@ -3476,60 +3319,34 @@ type STAT_MCTS struct {
 	EC_VALUE   float64 `json:"ec_value"`
 }
 
-type STAT_DMAP struct {
-	TOTAL      int     `json:"total"`
-	FY         int     `json:"fy"`
-	OY         int     `json:"oy"`
-	FBIAS      float64 `json:"fbias"`
-	BADDELEY   float64 `json:"baddeley"`
-	HAUSDORFF  float64 `json:"hausdorff"`
-	MED_FO     float64 `json:"med_fo"`
-	MED_OF     float64 `json:"med_of"`
-	MED_MIN    float64 `json:"med_min"`
-	MED_MAX    float64 `json:"med_max"`
-	MED_MEAN   float64 `json:"med_mean"`
-	FOM_FO     float64 `json:"fom_fo"`
-	FOM_OF     float64 `json:"fom_of"`
-	FOM_MIN    float64 `json:"fom_min"`
-	FOM_MAX    float64 `json:"fom_max"`
-	FOM_MEAN   float64 `json:"fom_mean"`
-	ZHU_FO     float64 `json:"zhu_fo"`
-	ZHU_OF     float64 `json:"zhu_of"`
-	ZHU_MIN    float64 `json:"zhu_min"`
-	ZHU_MAX    float64 `json:"zhu_max"`
-	ZHU_MEAN   float64 `json:"zhu_mean"`
-	G          float64 `json:"g"`
-	GBETA      float64 `json:"gbeta"`
-	BETA_VALUE float64 `json:"beta_value"`
-}
-
-type STAT_PJC struct {
+type STAT_PRC struct {
 	TOTAL  int                    `json:"total"`
 	THRESH map[string]interface{} `json:"thresh"`
 }
 
-type STAT_ECLV struct {
+type STAT_PSTD struct {
 	TOTAL       int                    `json:"total"`
-	BASER       float64                `json:"baser"`
-	VALUE_BASER int                    `json:"value_baser"`
-	PTS         map[string]interface{} `json:"pts"`
+	THRESH      map[string]interface{} `json:"thresh"`
+	BASER_NCL   float64                `json:"baser_ncl"`
+	BASER_NCU   float64                `json:"baser_ncu"`
+	RELIABILITY float64                `json:"reliability"`
+	RESOLUTION  float64                `json:"resolution"`
+	UNCERTAINTY float64                `json:"uncertainty"`
+	ROC_AUC     float64                `json:"roc_auc"`
+	BRIER       float64                `json:"brier"`
+	BRIER_NCL   float64                `json:"brier_ncl"`
+	BRIER_NCU   float64                `json:"brier_ncu"`
+	BRIERCL     float64                `json:"briercl"`
+	BRIERCL_NCL float64                `json:"briercl_ncl"`
+	BRIERCL_NCU float64                `json:"briercl_ncu"`
+	BSS         float64                `json:"bss"`
+	BSS_SMPL    float64                `json:"bss_smpl"`
+	THRESH_I    int                    `json:"thresh_i"`
 }
 
-type STAT_VAL1L2 struct {
-	TOTAL        int     `json:"total"`
-	UFABAR       float64 `json:"ufabar"`
-	VFABAR       float64 `json:"vfabar"`
-	UOABAR       float64 `json:"uoabar"`
-	VOABAR       float64 `json:"voabar"`
-	UVFOABAR     float64 `json:"uvfoabar"`
-	UVFFABAR     float64 `json:"uvffabar"`
-	UVOOABAR     float64 `json:"uvooabar"`
-	FA_SPEED_BAR float64 `json:"fa_speed_bar"`
-	OA_SPEED_BAR float64 `json:"oa_speed_bar"`
-	TOTAL_DIR    float64 `json:"total_dir"`
-	DIRA_ME      float64 `json:"dira_me"`
-	DIRA_MAE     float64 `json:"dira_mae"`
-	DIRA_MSE     float64 `json:"dira_mse"`
+type STAT_RHIST struct {
+	TOTAL int                    `json:"total"`
+	RANK  map[string]interface{} `json:"rank"`
 }
 
 type STAT_GENMPR struct {
@@ -3553,6 +3370,82 @@ type STAT_GENMPR struct {
 	OPS_CAT    string  `json:"ops_cat"`
 }
 
+type STAT_SEEPS struct {
+	TOTAL     int     `json:"total"`
+	ODFL      float64 `json:"odfl"`
+	ODFH      float64 `json:"odfh"`
+	OLFD      float64 `json:"olfd"`
+	OLFH      float64 `json:"olfh"`
+	OHFD      float64 `json:"ohfd"`
+	OHFL      float64 `json:"ohfl"`
+	PF1       float64 `json:"pf1"`
+	PF2       float64 `json:"pf2"`
+	PF3       float64 `json:"pf3"`
+	PV1       float64 `json:"pv1"`
+	PV2       float64 `json:"pv2"`
+	PV3       float64 `json:"pv3"`
+	MEAN_FCST float64 `json:"mean_fcst"`
+	MEAN_OBS  float64 `json:"mean_obs"`
+	SEEPS     float64 `json:"seeps"`
+}
+
+type STAT_RPS struct {
+	TOTAL     int     `json:"total"`
+	N_PROB    int     `json:"n_prob"`
+	RPS_REL   float64 `json:"rps_rel"`
+	RPS_RES   float64 `json:"rps_res"`
+	RPS_UNC   float64 `json:"rps_unc"`
+	RPS       float64 `json:"rps"`
+	RPSS      float64 `json:"rpss"`
+	RPSS_SMPL float64 `json:"rpss_smpl"`
+	RPS_COMP  float64 `json:"rps_comp"`
+}
+
+type STAT_RELP struct {
+	TOTAL int                    `json:"total"`
+	ENS   map[string]interface{} `json:"ens"`
+}
+
+type STAT_VAL1L2 struct {
+	TOTAL        int     `json:"total"`
+	UFABAR       float64 `json:"ufabar"`
+	VFABAR       float64 `json:"vfabar"`
+	UOABAR       float64 `json:"uoabar"`
+	VOABAR       float64 `json:"voabar"`
+	UVFOABAR     float64 `json:"uvfoabar"`
+	UVFFABAR     float64 `json:"uvffabar"`
+	UVOOABAR     float64 `json:"uvooabar"`
+	FA_SPEED_BAR float64 `json:"fa_speed_bar"`
+	OA_SPEED_BAR float64 `json:"oa_speed_bar"`
+	TOTAL_DIR    float64 `json:"total_dir"`
+	DIRA_ME      float64 `json:"dira_me"`
+	DIRA_MAE     float64 `json:"dira_mae"`
+	DIRA_MSE     float64 `json:"dira_mse"`
+}
+
+type MTD_3DSINGLE struct {
+	OBJECT_ID       string  `json:"object_id"`
+	OBJECT_CAT      string  `json:"object_cat"`
+	CENTROID_X      float64 `json:"centroid_x"`
+	CENTROID_Y      float64 `json:"centroid_y"`
+	CENTROID_T      float64 `json:"centroid_t"`
+	CENTROID_LAT    float64 `json:"centroid_lat"`
+	CENTROID_LON    float64 `json:"centroid_lon"`
+	X_DOT           float64 `json:"x_dot"`
+	Y_DOT           float64 `json:"y_dot"`
+	AXIS_ANG        float64 `json:"axis_ang"`
+	VOLUME          int     `json:"volume"`
+	START_TIME      int     `json:"start_time"`
+	END_TIME        int     `json:"end_time"`
+	CDIST_TRAVELLED float64 `json:"cdist_travelled"`
+	INTENSITY_10    float64 `json:"intensity_10"`
+	INTENSITY_25    float64 `json:"intensity_25"`
+	INTENSITY_50    float64 `json:"intensity_50"`
+	INTENSITY_75    float64 `json:"intensity_75"`
+	INTENSITY_90    float64 `json:"intensity_90"`
+	INTENSITY_USER  float64 `json:"intensity_user"`
+}
+
 type MTD_3DPAIR struct {
 	OBJECT_ID           string  `json:"object_id"`
 	OBJECT_CAT          string  `json:"object_cat"`
@@ -3567,6 +3460,16 @@ type MTD_3DPAIR struct {
 	INTERSECTION_VOLUME float64 `json:"intersection_volume"`
 	DURATION_DIFF       float64 `json:"duration_diff"`
 	INTEREST            float64 `json:"interest"`
+}
+
+type TCST_TCDIAG struct {
+	TOTAL        int                    `json:"total"`
+	INDEX        int                    `json:"index"`
+	DIAG_SOURCE  float64                `json:"diag_source"`
+	TRACK_SOURCE string                 `json:"track_source"`
+	FIELD_SOURCE string                 `json:"field_source"`
+	DIAG         map[string]interface{} `json:"diag"`
+	INIT         int                    `json:"init"`
 }
 
 type STAT_CTS struct {
@@ -3669,244 +3572,19 @@ type STAT_CTS struct {
 	EC_VALUE   float64 `json:"ec_value"`
 }
 
-type TCST_TCMPR struct {
-	TOTAL          int     `json:"total"`
-	INDEX          int     `json:"index"`
-	LEVEL          string  `json:"level"`
-	WATCH_WARN     string  `json:"watch_warn"`
-	INITIALS       string  `json:"initials"`
-	ALAT           float64 `json:"alat"`
-	ALON           float64 `json:"alon"`
-	BLAT           float64 `json:"blat"`
-	BLON           float64 `json:"blon"`
-	TK_ERR         float64 `json:"tk_err"`
-	X_ERR          float64 `json:"x_err"`
-	Y_ERR          float64 `json:"y_err"`
-	ALTK_ERR       float64 `json:"altk_err"`
-	CRTK_ERR       float64 `json:"crtk_err"`
-	ADLAND         float64 `json:"adland"`
-	BDLAND         float64 `json:"bdland"`
-	AMSLP          float64 `json:"amslp"`
-	BMSLP          float64 `json:"bmslp"`
-	AMAX_WIND      float64 `json:"amax_wind"`
-	BMAX_WIND      float64 `json:"bmax_wind"`
-	AAL_WIND_34    float64 `json:"aal_wind_34"`
-	BAL_WIND_34    float64 `json:"bal_wind_34"`
-	ANE_WIND_34    float64 `json:"ane_wind_34"`
-	BNE_WIND_34    float64 `json:"bne_wind_34"`
-	ASE_WIND_34    float64 `json:"ase_wind_34"`
-	BSE_WIND_34    float64 `json:"bse_wind_34"`
-	ASW_WIND_34    float64 `json:"asw_wind_34"`
-	BSW_WIND_34    float64 `json:"bsw_wind_34"`
-	ANW_WIND_34    float64 `json:"anw_wind_34"`
-	BNW_WIND_34    float64 `json:"bnw_wind_34"`
-	AAL_WIND_50    float64 `json:"aal_wind_50"`
-	BAL_WIND_50    float64 `json:"bal_wind_50"`
-	ANE_WIND_50    float64 `json:"ane_wind_50"`
-	BNE_WIND_50    float64 `json:"bne_wind_50"`
-	ASE_WIND_50    float64 `json:"ase_wind_50"`
-	BSE_WIND_50    float64 `json:"bse_wind_50"`
-	ASW_WIND_50    float64 `json:"asw_wind_50"`
-	BSW_WIND_50    float64 `json:"bsw_wind_50"`
-	ANW_WIND_50    float64 `json:"anw_wind_50"`
-	BNW_WIND_50    float64 `json:"bnw_wind_50"`
-	AAL_WIND_64    float64 `json:"aal_wind_64"`
-	BAL_WIND_64    float64 `json:"bal_wind_64"`
-	ANE_WIND_64    float64 `json:"ane_wind_64"`
-	BNE_WIND_64    float64 `json:"bne_wind_64"`
-	ASE_WIND_64    float64 `json:"ase_wind_64"`
-	BSE_WIND_64    float64 `json:"bse_wind_64"`
-	ASW_WIND_64    float64 `json:"asw_wind_64"`
-	BSW_WIND_64    float64 `json:"bsw_wind_64"`
-	ANW_WIND_64    float64 `json:"anw_wind_64"`
-	BNW_WIND_64    float64 `json:"bnw_wind_64"`
-	ARADP          string  `json:"aradp"`
-	BRADP          float64 `json:"bradp"`
-	ARRP           int     `json:"arrp"`
-	BRRP           float64 `json:"brrp"`
-	AMRD           int     `json:"amrd"`
-	BMRD           float64 `json:"bmrd"`
-	AGUSTS         int     `json:"agusts"`
-	BGUSTS         float64 `json:"bgusts"`
-	AEYE           int     `json:"aeye"`
-	BEYE           float64 `json:"beye"`
-	ADIR           int     `json:"adir"`
-	BDIR           float64 `json:"bdir"`
-	ASPEED         int     `json:"aspeed"`
-	BSPEED         float64 `json:"bspeed"`
-	ADEPTH         int     `json:"adepth"`
-	BDEPTH         float64 `json:"bdepth"`
-	NUM_MEMBERS    float64 `json:"num_members"`
-	TRACK_SPREAD   float64 `json:"track_spread"`
-	TRACK_STDEV    float64 `json:"track_stdev"`
-	MSLP_STDEV     float64 `json:"mslp_stdev"`
-	MAX_WIND_STDEV float64 `json:"max_wind_stdev"`
-	INIT           int     `json:"init"`
-}
-
-type STAT_SEEPS struct {
-	TOTAL     int     `json:"total"`
-	ODFL      float64 `json:"odfl"`
-	ODFH      float64 `json:"odfh"`
-	OLFD      float64 `json:"olfd"`
-	OLFH      float64 `json:"olfh"`
-	OHFD      float64 `json:"ohfd"`
-	OHFL      float64 `json:"ohfl"`
-	PF1       float64 `json:"pf1"`
-	PF2       float64 `json:"pf2"`
-	PF3       float64 `json:"pf3"`
-	PV1       float64 `json:"pv1"`
-	PV2       float64 `json:"pv2"`
-	PV3       float64 `json:"pv3"`
-	MEAN_FCST float64 `json:"mean_fcst"`
-	MEAN_OBS  float64 `json:"mean_obs"`
-	SEEPS     float64 `json:"seeps"`
-}
-
-type STAT_RHIST struct {
-	TOTAL int                    `json:"total"`
-	RANK  map[string]interface{} `json:"rank"`
-}
-
-type STAT_SAL1L2 struct {
-	TOTAL  int     `json:"total"`
-	FABAR  float64 `json:"fabar"`
-	OABAR  float64 `json:"oabar"`
-	FOABAR float64 `json:"foabar"`
-	FFABAR float64 `json:"ffabar"`
-	OOABAR float64 `json:"ooabar"`
-	MAE    float64 `json:"mae"`
-}
-
-type STAT_VCNT struct {
-	TOTAL                int     `json:"total"`
-	FBAR                 float64 `json:"fbar"`
-	FBAR_BCL             float64 `json:"fbar_bcl"`
-	FBAR_BCU             float64 `json:"fbar_bcu"`
-	OBAR                 float64 `json:"obar"`
-	OBAR_BCL             float64 `json:"obar_bcl"`
-	OBAR_BCU             float64 `json:"obar_bcu"`
-	FS_RMS               float64 `json:"fs_rms"`
-	FS_RMS_BCL           float64 `json:"fs_rms_bcl"`
-	FS_RMS_BCU           float64 `json:"fs_rms_bcu"`
-	OS_RMS               float64 `json:"os_rms"`
-	OS_RMS_BCL           float64 `json:"os_rms_bcl"`
-	OS_RMS_BCU           float64 `json:"os_rms_bcu"`
-	MSVE                 float64 `json:"msve"`
-	MSVE_BCL             float64 `json:"msve_bcl"`
-	MSVE_BCU             float64 `json:"msve_bcu"`
-	RMSVE                float64 `json:"rmsve"`
-	RMSVE_BCL            float64 `json:"rmsve_bcl"`
-	RMSVE_BCU            float64 `json:"rmsve_bcu"`
-	FSTDEV               float64 `json:"fstdev"`
-	FSTDEV_BCL           float64 `json:"fstdev_bcl"`
-	FSTDEV_BCU           float64 `json:"fstdev_bcu"`
-	OSTDEV               float64 `json:"ostdev"`
-	OSTDEV_BCL           float64 `json:"ostdev_bcl"`
-	OSTDEV_BCU           float64 `json:"ostdev_bcu"`
-	FDIR                 float64 `json:"fdir"`
-	FDIR_BCL             float64 `json:"fdir_bcl"`
-	FDIR_BCU             float64 `json:"fdir_bcu"`
-	ODIR                 float64 `json:"odir"`
-	ODIR_BCL             float64 `json:"odir_bcl"`
-	ODIR_BCU             float64 `json:"odir_bcu"`
-	FBAR_SPEED           float64 `json:"fbar_speed"`
-	FBAR_SPEED_BCL       float64 `json:"fbar_speed_bcl"`
-	FBAR_SPEED_BCU       float64 `json:"fbar_speed_bcu"`
-	OBAR_SPEED           float64 `json:"obar_speed"`
-	OBAR_SPEED_BCL       float64 `json:"obar_speed_bcl"`
-	OBAR_SPEED_BCU       float64 `json:"obar_speed_bcu"`
-	VDIFF_SPEED          float64 `json:"vdiff_speed"`
-	VDIFF_SPEED_BCL      float64 `json:"vdiff_speed_bcl"`
-	VDIFF_SPEED_BCU      float64 `json:"vdiff_speed_bcu"`
-	VDIFF_DIR            float64 `json:"vdiff_dir"`
-	VDIFF_DIR_BCL        float64 `json:"vdiff_dir_bcl"`
-	VDIFF_DIR_BCU        float64 `json:"vdiff_dir_bcu"`
-	SPEED_ERR            float64 `json:"speed_err"`
-	SPEED_ERR_BCL        float64 `json:"speed_err_bcl"`
-	SPEED_ERR_BCU        float64 `json:"speed_err_bcu"`
-	SPEED_ABSERR         float64 `json:"speed_abserr"`
-	SPEED_ABSERR_BCL     float64 `json:"speed_abserr_bcl"`
-	SPEED_ABSERR_BCU     float64 `json:"speed_abserr_bcu"`
-	DIR_ERR              float64 `json:"dir_err"`
-	DIR_ERR_BCL          float64 `json:"dir_err_bcl"`
-	DIR_ERR_BCU          float64 `json:"dir_err_bcu"`
-	DIR_ABSERR           float64 `json:"dir_abserr"`
-	DIR_ABSERR_BCL       float64 `json:"dir_abserr_bcl"`
-	DIR_ABSERR_BCU       float64 `json:"dir_abserr_bcu"`
-	ANOM_CORR            float64 `json:"anom_corr"`
-	ANOM_CORR_NCL        float64 `json:"anom_corr_ncl"`
-	ANOM_CORR_NCU        float64 `json:"anom_corr_ncu"`
-	ANOM_CORR_BCL        float64 `json:"anom_corr_bcl"`
-	ANOM_CORR_BCU        float64 `json:"anom_corr_bcu"`
-	ANOM_CORR_UNCNTR     float64 `json:"anom_corr_uncntr"`
-	ANOM_CORR_UNCNTR_BCL float64 `json:"anom_corr_uncntr_bcl"`
-	ANOM_CORR_UNCNTR_BCU float64 `json:"anom_corr_uncntr_bcu"`
-	TOTAL_DIR            float64 `json:"total_dir"`
-	DIR_ME               float64 `json:"dir_me"`
-	DIR_ME_BCL           float64 `json:"dir_me_bcl"`
-	DIR_ME_BCU           float64 `json:"dir_me_bcu"`
-	DIR_MAE              float64 `json:"dir_mae"`
-	DIR_MAE_BCL          float64 `json:"dir_mae_bcl"`
-	DIR_MAE_BCU          float64 `json:"dir_mae_bcu"`
-	DIR_MSE              float64 `json:"dir_mse"`
-	DIR_MSE_BCL          float64 `json:"dir_mse_bcl"`
-	DIR_MSE_BCU          float64 `json:"dir_mse_bcu"`
-	DIR_RMSE             float64 `json:"dir_rmse"`
-	DIR_RMSE_BCL         float64 `json:"dir_rmse_bcl"`
-	DIR_RMSE_BCU         float64 `json:"dir_rmse_bcu"`
-}
-
-type MODE_CTS struct {
-	FIELD string  `json:"field"`
-	TOTAL int     `json:"total"`
-	FY_OY float64 `json:"fy_oy"`
-	FY_ON float64 `json:"fy_on"`
-	FN_OY float64 `json:"fn_oy"`
-	FN_ON float64 `json:"fn_on"`
-	BASER float64 `json:"baser"`
-	FMEAN float64 `json:"fmean"`
-	ACC   float64 `json:"acc"`
-	FBIAS float64 `json:"fbias"`
-	PODY  float64 `json:"pody"`
-	PODN  float64 `json:"podn"`
-	POFD  float64 `json:"pofd"`
-	FAR   float64 `json:"far"`
-	CSI   float64 `json:"csi"`
-	GSS   float64 `json:"gss"`
-	HK    float64 `json:"hk"`
-	HSS   float64 `json:"hss"`
-	ODDS  float64 `json:"odds"`
-	LODDS float64 `json:"lodds"`
-	ORSS  float64 `json:"orss"`
-	EDS   float64 `json:"eds"`
-	SEDS  float64 `json:"seds"`
-	EDI   float64 `json:"edi"`
-	SEDI  float64 `json:"sedi"`
-	BAGSS float64 `json:"bagss"`
-}
-
-type MTD_3DSINGLE struct {
-	OBJECT_ID       string  `json:"object_id"`
-	OBJECT_CAT      string  `json:"object_cat"`
-	CENTROID_X      float64 `json:"centroid_x"`
-	CENTROID_Y      float64 `json:"centroid_y"`
-	CENTROID_T      float64 `json:"centroid_t"`
-	CENTROID_LAT    float64 `json:"centroid_lat"`
-	CENTROID_LON    float64 `json:"centroid_lon"`
-	X_DOT           float64 `json:"x_dot"`
-	Y_DOT           float64 `json:"y_dot"`
-	AXIS_ANG        float64 `json:"axis_ang"`
-	VOLUME          int     `json:"volume"`
-	START_TIME      int     `json:"start_time"`
-	END_TIME        int     `json:"end_time"`
-	CDIST_TRAVELLED float64 `json:"cdist_travelled"`
-	INTENSITY_10    float64 `json:"intensity_10"`
-	INTENSITY_25    float64 `json:"intensity_25"`
-	INTENSITY_50    float64 `json:"intensity_50"`
-	INTENSITY_75    float64 `json:"intensity_75"`
-	INTENSITY_90    float64 `json:"intensity_90"`
-	INTENSITY_USER  float64 `json:"intensity_user"`
+type STAT_ISC struct {
+	TOTAL    int     `json:"total"`
+	TILE_DIM int     `json:"tile_dim"`
+	TILE_XLL int     `json:"tile_xll"`
+	TILE_YLL int     `json:"tile_yll"`
+	NSCALE   int     `json:"nscale"`
+	ISCALE   int     `json:"iscale"`
+	MSE      float64 `json:"mse"`
+	ISC      float64 `json:"isc"`
+	FENERGY2 float64 `json:"fenergy2"`
+	OENERGY2 float64 `json:"oenergy2"`
+	BASER    float64 `json:"baser"`
+	FBIAS    float64 `json:"fbias"`
 }
 
 type STAT_MCTC struct {
@@ -3915,11 +3593,121 @@ type STAT_MCTC struct {
 	EC_VALUE float64                `json:"ec_value"`
 }
 
+type STAT_GRAD struct {
+	TOTAL      int     `json:"total"`
+	FGBAR      float64 `json:"fgbar"`
+	OGBAR      float64 `json:"ogbar"`
+	MGBAR      float64 `json:"mgbar"`
+	EGBAR      float64 `json:"egbar"`
+	S1         float64 `json:"s1"`
+	S1_OG      float64 `json:"s1_og"`
+	FGOG_RATIO float64 `json:"fgog_ratio"`
+	DX         float64 `json:"dx"`
+	DY         float64 `json:"dy"`
+}
+
+type STAT_DMAP struct {
+	TOTAL      int     `json:"total"`
+	FY         int     `json:"fy"`
+	OY         int     `json:"oy"`
+	FBIAS      float64 `json:"fbias"`
+	BADDELEY   float64 `json:"baddeley"`
+	HAUSDORFF  float64 `json:"hausdorff"`
+	MED_FO     float64 `json:"med_fo"`
+	MED_OF     float64 `json:"med_of"`
+	MED_MIN    float64 `json:"med_min"`
+	MED_MAX    float64 `json:"med_max"`
+	MED_MEAN   float64 `json:"med_mean"`
+	FOM_FO     float64 `json:"fom_fo"`
+	FOM_OF     float64 `json:"fom_of"`
+	FOM_MIN    float64 `json:"fom_min"`
+	FOM_MAX    float64 `json:"fom_max"`
+	FOM_MEAN   float64 `json:"fom_mean"`
+	ZHU_FO     float64 `json:"zhu_fo"`
+	ZHU_OF     float64 `json:"zhu_of"`
+	ZHU_MIN    float64 `json:"zhu_min"`
+	ZHU_MAX    float64 `json:"zhu_max"`
+	ZHU_MEAN   float64 `json:"zhu_mean"`
+	G          float64 `json:"g"`
+	GBETA      float64 `json:"gbeta"`
+	BETA_VALUE float64 `json:"beta_value"`
+}
+
+type STAT_PJC struct {
+	TOTAL  int                    `json:"total"`
+	THRESH map[string]interface{} `json:"thresh"`
+}
+
+type STAT_ECNT struct {
+	TOTAL            int     `json:"total"`
+	N_ENS            int     `json:"n_ens"`
+	CRPS             float64 `json:"crps"`
+	CRPSS            float64 `json:"crpss"`
+	IGN              float64 `json:"ign"`
+	ME               float64 `json:"me"`
+	RMSE             float64 `json:"rmse"`
+	SPREAD           float64 `json:"spread"`
+	ME_OERR          float64 `json:"me_oerr"`
+	RMSE_OERR        float64 `json:"rmse_oerr"`
+	SPREAD_OERR      float64 `json:"spread_oerr"`
+	SPREAD_PLUS_OERR float64 `json:"spread_plus_oerr"`
+	CRPSCL           float64 `json:"crpscl"`
+	CRPS_EMP         float64 `json:"crps_emp"`
+	CRPSCL_EMP       float64 `json:"crpscl_emp"`
+	CRPSS_EMP        float64 `json:"crpss_emp"`
+	CRPS_EMP_FAIR    float64 `json:"crps_emp_fair"`
+	SPREAD_MD        float64 `json:"spread_md"`
+	MAE              float64 `json:"mae"`
+	MAE_OERR         float64 `json:"mae_oerr"`
+	BIAS_RATIO       float64 `json:"bias_ratio"`
+	N_GE_OBS         int     `json:"n_ge_obs"`
+	ME_GE_OBS        float64 `json:"me_ge_obs"`
+	N_LT_OBS         int     `json:"n_lt_obs"`
+	ME_LT_OBS        float64 `json:"me_lt_obs"`
+	IGN_CONV_OERR    float64 `json:"ign_conv_oerr"`
+	IGN_CORR_OERR    float64 `json:"ign_corr_oerr"`
+}
+
+type STAT_CTC struct {
+	TOTAL    int     `json:"total"`
+	FY_OY    float64 `json:"fy_oy"`
+	FY_ON    float64 `json:"fy_on"`
+	FN_OY    float64 `json:"fn_oy"`
+	FN_ON    float64 `json:"fn_on"`
+	EC_VALUE float64 `json:"ec_value"`
+}
+
 type STAT_FHO struct {
 	TOTAL  int     `json:"total"`
 	F_RATE float64 `json:"f_rate"`
 	H_RATE float64 `json:"h_rate"`
 	O_RATE float64 `json:"o_rate"`
+}
+
+type STAT_MPR struct {
+	TOTAL            int     `json:"total"`
+	INDEX            int     `json:"index"`
+	OBS_SID          string  `json:"obs_sid"`
+	OBS_LAT          float64 `json:"obs_lat"`
+	OBS_LON          float64 `json:"obs_lon"`
+	OBS_LVL          float64 `json:"obs_lvl"`
+	OBS_ELV          float64 `json:"obs_elv"`
+	FCST             float64 `json:"fcst"`
+	OBS              float64 `json:"obs"`
+	OBS_QC           string  `json:"obs_qc"`
+	OBS_CLIMO_MEAN   float64 `json:"obs_climo_mean"`
+	OBS_CLIMO_STDEV  float64 `json:"obs_climo_stdev"`
+	OBS_CLIMO_CDF    float64 `json:"obs_climo_cdf"`
+	FCST_CLIMO_MEAN  float64 `json:"fcst_climo_mean"`
+	FCST_CLIMO_STDEV float64 `json:"fcst_climo_stdev"`
+}
+
+type STAT_NBRCTC struct {
+	TOTAL int     `json:"total"`
+	FY_OY float64 `json:"fy_oy"`
+	FY_ON float64 `json:"fy_on"`
+	FN_OY float64 `json:"fn_oy"`
+	FN_ON float64 `json:"fn_on"`
 }
 
 type STAT_NBRCTS struct {
@@ -4018,75 +3806,113 @@ type STAT_NBRCTS struct {
 	BAGSS_BCU float64 `json:"bagss_bcu"`
 }
 
-type STAT_GRAD struct {
+type STAT_NBRCNT struct {
 	TOTAL      int     `json:"total"`
-	FGBAR      float64 `json:"fgbar"`
-	OGBAR      float64 `json:"ogbar"`
-	MGBAR      float64 `json:"mgbar"`
-	EGBAR      float64 `json:"egbar"`
-	S1         float64 `json:"s1"`
-	S1_OG      float64 `json:"s1_og"`
-	FGOG_RATIO float64 `json:"fgog_ratio"`
-	DX         float64 `json:"dx"`
-	DY         float64 `json:"dy"`
+	FBS        float64 `json:"fbs"`
+	FBS_BCL    float64 `json:"fbs_bcl"`
+	FBS_BCU    float64 `json:"fbs_bcu"`
+	FSS        float64 `json:"fss"`
+	FSS_BCL    float64 `json:"fss_bcl"`
+	FSS_BCU    float64 `json:"fss_bcu"`
+	AFSS       float64 `json:"afss"`
+	AFSS_BCL   float64 `json:"afss_bcl"`
+	AFSS_BCU   float64 `json:"afss_bcu"`
+	UFSS       float64 `json:"ufss"`
+	UFSS_BCL   float64 `json:"ufss_bcl"`
+	UFSS_BCU   float64 `json:"ufss_bcu"`
+	F_RATE     float64 `json:"f_rate"`
+	F_RATE_BCL float64 `json:"f_rate_bcl"`
+	F_RATE_BCU float64 `json:"f_rate_bcu"`
+	O_RATE     float64 `json:"o_rate"`
+	O_RATE_BCL float64 `json:"o_rate_bcl"`
+	O_RATE_BCU float64 `json:"o_rate_bcu"`
 }
 
-type STAT_PCT struct {
-	TOTAL  int                    `json:"total"`
-	THRESH map[string]interface{} `json:"thresh"`
+type STAT_SAL1L2 struct {
+	TOTAL  int     `json:"total"`
+	FABAR  float64 `json:"fabar"`
+	OABAR  float64 `json:"oabar"`
+	FOABAR float64 `json:"foabar"`
+	FFABAR float64 `json:"ffabar"`
+	OOABAR float64 `json:"ooabar"`
+	MAE    float64 `json:"mae"`
 }
 
-type STAT_PRC struct {
-	TOTAL  int                    `json:"total"`
-	THRESH map[string]interface{} `json:"thresh"`
+type STAT_SSIDX struct {
+	FCST_MODEL string  `json:"fcst_model"`
+	REF_MODEL  string  `json:"ref_model"`
+	N_INIT     int     `json:"n_init"`
+	N_TERM     int     `json:"n_term"`
+	N_VLD      int     `json:"n_vld"`
+	SS_INDEX   float64 `json:"ss_index"`
 }
 
-type STAT_ECNT struct {
-	TOTAL            int     `json:"total"`
-	N_ENS            int     `json:"n_ens"`
-	CRPS             float64 `json:"crps"`
-	CRPSS            float64 `json:"crpss"`
-	IGN              float64 `json:"ign"`
-	ME               float64 `json:"me"`
-	RMSE             float64 `json:"rmse"`
-	SPREAD           float64 `json:"spread"`
-	ME_OERR          float64 `json:"me_oerr"`
-	RMSE_OERR        float64 `json:"rmse_oerr"`
-	SPREAD_OERR      float64 `json:"spread_oerr"`
-	SPREAD_PLUS_OERR float64 `json:"spread_plus_oerr"`
-	CRPSCL           float64 `json:"crpscl"`
-	CRPS_EMP         float64 `json:"crps_emp"`
-	CRPSCL_EMP       float64 `json:"crpscl_emp"`
-	CRPSS_EMP        float64 `json:"crpss_emp"`
-	CRPS_EMP_FAIR    float64 `json:"crps_emp_fair"`
-	SPREAD_MD        float64 `json:"spread_md"`
-	MAE              float64 `json:"mae"`
-	MAE_OERR         float64 `json:"mae_oerr"`
-	BIAS_RATIO       float64 `json:"bias_ratio"`
-	N_GE_OBS         int     `json:"n_ge_obs"`
-	ME_GE_OBS        float64 `json:"me_ge_obs"`
-	N_LT_OBS         int     `json:"n_lt_obs"`
-	ME_LT_OBS        float64 `json:"me_lt_obs"`
-	IGN_CONV_OERR    float64 `json:"ign_conv_oerr"`
-	IGN_CORR_OERR    float64 `json:"ign_corr_oerr"`
+type MODE_OBJ struct {
+	OBJECT_ID                  string  `json:"object_id"`
+	OBJECT_CAT                 string  `json:"object_cat"`
+	CENTROID_X                 float64 `json:"centroid_x"`
+	CENTROID_Y                 float64 `json:"centroid_y"`
+	CENTROID_LAT               float64 `json:"centroid_lat"`
+	CENTROID_LON               float64 `json:"centroid_lon"`
+	AXIS_ANG                   float64 `json:"axis_ang"`
+	LENGTH                     float64 `json:"length"`
+	WIDTH                      float64 `json:"width"`
+	AREA                       int     `json:"area"`
+	AREA_THRESH                int     `json:"area_thresh"`
+	CURVATURE                  float64 `json:"curvature"`
+	CURVATURE_X                float64 `json:"curvature_x"`
+	CURVATURE_Y                float64 `json:"curvature_y"`
+	COMPLEXITY                 float64 `json:"complexity"`
+	INTENSITY_10               float64 `json:"intensity_10"`
+	INTENSITY_25               float64 `json:"intensity_25"`
+	INTENSITY_50               float64 `json:"intensity_50"`
+	INTENSITY_75               float64 `json:"intensity_75"`
+	INTENSITY_90               float64 `json:"intensity_90"`
+	INTENSITY_USER             float64 `json:"intensity_user"`
+	INTENSITY_SUM              float64 `json:"intensity_sum"`
+	CENTROID_DIST              float64 `json:"centroid_dist"`
+	BOUNDARY_DIST              float64 `json:"boundary_dist"`
+	CONVEX_HULL_DIST           float64 `json:"convex_hull_dist"`
+	ANGLE_DIFF                 float64 `json:"angle_diff"`
+	ASPECT_DIFF                float64 `json:"aspect_diff"`
+	AREA_RATIO                 float64 `json:"area_ratio"`
+	INTERSECTION_AREA          float64 `json:"intersection_area"`
+	UNION_AREA                 float64 `json:"union_area"`
+	SYMMETRIC_DIFF             float64 `json:"symmetric_diff"`
+	INTERSECTION_OVER_AREA     float64 `json:"intersection_over_area"`
+	CURVATURE_RATIO            float64 `json:"curvature_ratio"`
+	COMPLEXITY_RATIO           float64 `json:"complexity_ratio"`
+	PERCENTILE_INTENSITY_RATIO float64 `json:"percentile_intensity_ratio"`
+	INTEREST                   float64 `json:"interest"`
 }
 
-type MTD_2DSINGLE struct {
-	OBJECT_ID      string  `json:"object_id"`
-	OBJECT_CAT     string  `json:"object_cat"`
-	TIME_INDEX     int     `json:"time_index"`
-	AREA           int     `json:"area"`
-	CENTROID_X     float64 `json:"centroid_x"`
-	CENTROID_Y     float64 `json:"centroid_y"`
-	CENTROID_LAT   float64 `json:"centroid_lat"`
-	CENTROID_LON   float64 `json:"centroid_lon"`
-	AXIS_ANG       float64 `json:"axis_ang"`
-	INTENSITY_10   float64 `json:"intensity_10"`
-	INTENSITY_25   float64 `json:"intensity_25"`
-	INTENSITY_50   float64 `json:"intensity_50"`
-	INTENSITY_75   float64 `json:"intensity_75"`
-	INTENSITY_90   float64 `json:"intensity_90"`
-	INTENSITY_USER float64 `json:"intensity_user"`
+type MODE_CTS struct {
+	FIELD string  `json:"field"`
+	TOTAL int     `json:"total"`
+	FY_OY float64 `json:"fy_oy"`
+	FY_ON float64 `json:"fy_on"`
+	FN_OY float64 `json:"fn_oy"`
+	FN_ON float64 `json:"fn_on"`
+	BASER float64 `json:"baser"`
+	FMEAN float64 `json:"fmean"`
+	ACC   float64 `json:"acc"`
+	FBIAS float64 `json:"fbias"`
+	PODY  float64 `json:"pody"`
+	PODN  float64 `json:"podn"`
+	POFD  float64 `json:"pofd"`
+	FAR   float64 `json:"far"`
+	CSI   float64 `json:"csi"`
+	GSS   float64 `json:"gss"`
+	HK    float64 `json:"hk"`
+	HSS   float64 `json:"hss"`
+	ODDS  float64 `json:"odds"`
+	LODDS float64 `json:"lodds"`
+	ORSS  float64 `json:"orss"`
+	EDS   float64 `json:"eds"`
+	SEDS  float64 `json:"seds"`
+	EDI   float64 `json:"edi"`
+	SEDI  float64 `json:"sedi"`
+	BAGSS float64 `json:"bagss"`
 }
 
 type STAT_CNT struct {
@@ -4192,87 +4018,261 @@ type STAT_CNT struct {
 	SI_BCU               float64 `json:"si_bcu"`
 }
 
-type STAT_PSTD struct {
-	TOTAL       int                    `json:"total"`
-	THRESH      map[string]interface{} `json:"thresh"`
-	BASER_NCL   float64                `json:"baser_ncl"`
-	BASER_NCU   float64                `json:"baser_ncu"`
-	RELIABILITY float64                `json:"reliability"`
-	RESOLUTION  float64                `json:"resolution"`
-	UNCERTAINTY float64                `json:"uncertainty"`
-	ROC_AUC     float64                `json:"roc_auc"`
-	BRIER       float64                `json:"brier"`
-	BRIER_NCL   float64                `json:"brier_ncl"`
-	BRIER_NCU   float64                `json:"brier_ncu"`
-	BRIERCL     float64                `json:"briercl"`
-	BRIERCL_NCL float64                `json:"briercl_ncl"`
-	BRIERCL_NCU float64                `json:"briercl_ncu"`
-	BSS         float64                `json:"bss"`
-	BSS_SMPL    float64                `json:"bss_smpl"`
-	THRESH_I    int                    `json:"thresh_i"`
-}
-
-type STAT_RPS struct {
-	TOTAL     int     `json:"total"`
-	N_PROB    int     `json:"n_prob"`
-	RPS_REL   float64 `json:"rps_rel"`
-	RPS_RES   float64 `json:"rps_res"`
-	RPS_UNC   float64 `json:"rps_unc"`
-	RPS       float64 `json:"rps"`
-	RPSS      float64 `json:"rpss"`
-	RPSS_SMPL float64 `json:"rpss_smpl"`
-	RPS_COMP  float64 `json:"rps_comp"`
-}
-
-type TCST_TCDIAG struct {
-	TOTAL        int                    `json:"total"`
-	INDEX        int                    `json:"index"`
-	DIAG_SOURCE  float64                `json:"diag_source"`
-	TRACK_SOURCE string                 `json:"track_source"`
-	FIELD_SOURCE string                 `json:"field_source"`
-	DIAG         map[string]interface{} `json:"diag"`
-	INIT         int                    `json:"init"`
-}
-
-type STAT_NBRCNT struct {
-	TOTAL      int     `json:"total"`
-	FBS        float64 `json:"fbs"`
-	FBS_BCL    float64 `json:"fbs_bcl"`
-	FBS_BCU    float64 `json:"fbs_bcu"`
-	FSS        float64 `json:"fss"`
-	FSS_BCL    float64 `json:"fss_bcl"`
-	FSS_BCU    float64 `json:"fss_bcu"`
-	AFSS       float64 `json:"afss"`
-	AFSS_BCL   float64 `json:"afss_bcl"`
-	AFSS_BCU   float64 `json:"afss_bcu"`
-	UFSS       float64 `json:"ufss"`
-	UFSS_BCL   float64 `json:"ufss_bcl"`
-	UFSS_BCU   float64 `json:"ufss_bcu"`
-	F_RATE     float64 `json:"f_rate"`
-	F_RATE_BCL float64 `json:"f_rate_bcl"`
-	F_RATE_BCU float64 `json:"f_rate_bcu"`
-	O_RATE     float64 `json:"o_rate"`
-	O_RATE_BCL float64 `json:"o_rate_bcl"`
-	O_RATE_BCU float64 `json:"o_rate_bcu"`
-}
-
 type STAT_PHIST struct {
 	TOTAL    int                    `json:"total"`
 	BIN_SIZE int                    `json:"bin_size"`
 	BIN      map[string]interface{} `json:"bin"`
 }
 
-type STAT_CTC struct {
-	TOTAL    int     `json:"total"`
-	FY_OY    float64 `json:"fy_oy"`
-	FY_ON    float64 `json:"fy_on"`
-	FN_OY    float64 `json:"fn_oy"`
-	FN_ON    float64 `json:"fn_on"`
-	EC_VALUE float64 `json:"ec_value"`
+type STAT_VL1L2 struct {
+	TOTAL       int     `json:"total"`
+	UFBAR       float64 `json:"ufbar"`
+	VFBAR       float64 `json:"vfbar"`
+	UOBAR       float64 `json:"uobar"`
+	VOBAR       float64 `json:"vobar"`
+	UVFOBAR     float64 `json:"uvfobar"`
+	UVFFBAR     float64 `json:"uvffbar"`
+	UVOOBAR     float64 `json:"uvoobar"`
+	F_SPEED_BAR float64 `json:"f_speed_bar"`
+	O_SPEED_BAR float64 `json:"o_speed_bar"`
+	TOTAL_DIR   float64 `json:"total_dir"`
+	DIR_ME      float64 `json:"dir_me"`
+	DIR_MAE     float64 `json:"dir_mae"`
+	DIR_MSE     float64 `json:"dir_mse"`
+}
+
+type STAT_VCNT struct {
+	TOTAL                int     `json:"total"`
+	FBAR                 float64 `json:"fbar"`
+	FBAR_BCL             float64 `json:"fbar_bcl"`
+	FBAR_BCU             float64 `json:"fbar_bcu"`
+	OBAR                 float64 `json:"obar"`
+	OBAR_BCL             float64 `json:"obar_bcl"`
+	OBAR_BCU             float64 `json:"obar_bcu"`
+	FS_RMS               float64 `json:"fs_rms"`
+	FS_RMS_BCL           float64 `json:"fs_rms_bcl"`
+	FS_RMS_BCU           float64 `json:"fs_rms_bcu"`
+	OS_RMS               float64 `json:"os_rms"`
+	OS_RMS_BCL           float64 `json:"os_rms_bcl"`
+	OS_RMS_BCU           float64 `json:"os_rms_bcu"`
+	MSVE                 float64 `json:"msve"`
+	MSVE_BCL             float64 `json:"msve_bcl"`
+	MSVE_BCU             float64 `json:"msve_bcu"`
+	RMSVE                float64 `json:"rmsve"`
+	RMSVE_BCL            float64 `json:"rmsve_bcl"`
+	RMSVE_BCU            float64 `json:"rmsve_bcu"`
+	FSTDEV               float64 `json:"fstdev"`
+	FSTDEV_BCL           float64 `json:"fstdev_bcl"`
+	FSTDEV_BCU           float64 `json:"fstdev_bcu"`
+	OSTDEV               float64 `json:"ostdev"`
+	OSTDEV_BCL           float64 `json:"ostdev_bcl"`
+	OSTDEV_BCU           float64 `json:"ostdev_bcu"`
+	FDIR                 float64 `json:"fdir"`
+	FDIR_BCL             float64 `json:"fdir_bcl"`
+	FDIR_BCU             float64 `json:"fdir_bcu"`
+	ODIR                 float64 `json:"odir"`
+	ODIR_BCL             float64 `json:"odir_bcl"`
+	ODIR_BCU             float64 `json:"odir_bcu"`
+	FBAR_SPEED           float64 `json:"fbar_speed"`
+	FBAR_SPEED_BCL       float64 `json:"fbar_speed_bcl"`
+	FBAR_SPEED_BCU       float64 `json:"fbar_speed_bcu"`
+	OBAR_SPEED           float64 `json:"obar_speed"`
+	OBAR_SPEED_BCL       float64 `json:"obar_speed_bcl"`
+	OBAR_SPEED_BCU       float64 `json:"obar_speed_bcu"`
+	VDIFF_SPEED          float64 `json:"vdiff_speed"`
+	VDIFF_SPEED_BCL      float64 `json:"vdiff_speed_bcl"`
+	VDIFF_SPEED_BCU      float64 `json:"vdiff_speed_bcu"`
+	VDIFF_DIR            float64 `json:"vdiff_dir"`
+	VDIFF_DIR_BCL        float64 `json:"vdiff_dir_bcl"`
+	VDIFF_DIR_BCU        float64 `json:"vdiff_dir_bcu"`
+	SPEED_ERR            float64 `json:"speed_err"`
+	SPEED_ERR_BCL        float64 `json:"speed_err_bcl"`
+	SPEED_ERR_BCU        float64 `json:"speed_err_bcu"`
+	SPEED_ABSERR         float64 `json:"speed_abserr"`
+	SPEED_ABSERR_BCL     float64 `json:"speed_abserr_bcl"`
+	SPEED_ABSERR_BCU     float64 `json:"speed_abserr_bcu"`
+	DIR_ERR              float64 `json:"dir_err"`
+	DIR_ERR_BCL          float64 `json:"dir_err_bcl"`
+	DIR_ERR_BCU          float64 `json:"dir_err_bcu"`
+	DIR_ABSERR           float64 `json:"dir_abserr"`
+	DIR_ABSERR_BCL       float64 `json:"dir_abserr_bcl"`
+	DIR_ABSERR_BCU       float64 `json:"dir_abserr_bcu"`
+	ANOM_CORR            float64 `json:"anom_corr"`
+	ANOM_CORR_NCL        float64 `json:"anom_corr_ncl"`
+	ANOM_CORR_NCU        float64 `json:"anom_corr_ncu"`
+	ANOM_CORR_BCL        float64 `json:"anom_corr_bcl"`
+	ANOM_CORR_BCU        float64 `json:"anom_corr_bcu"`
+	ANOM_CORR_UNCNTR     float64 `json:"anom_corr_uncntr"`
+	ANOM_CORR_UNCNTR_BCL float64 `json:"anom_corr_uncntr_bcl"`
+	ANOM_CORR_UNCNTR_BCU float64 `json:"anom_corr_uncntr_bcu"`
+	TOTAL_DIR            float64 `json:"total_dir"`
+	DIR_ME               float64 `json:"dir_me"`
+	DIR_ME_BCL           float64 `json:"dir_me_bcl"`
+	DIR_ME_BCU           float64 `json:"dir_me_bcu"`
+	DIR_MAE              float64 `json:"dir_mae"`
+	DIR_MAE_BCL          float64 `json:"dir_mae_bcl"`
+	DIR_MAE_BCU          float64 `json:"dir_mae_bcu"`
+	DIR_MSE              float64 `json:"dir_mse"`
+	DIR_MSE_BCL          float64 `json:"dir_mse_bcl"`
+	DIR_MSE_BCU          float64 `json:"dir_mse_bcu"`
+	DIR_RMSE             float64 `json:"dir_rmse"`
+	DIR_RMSE_BCL         float64 `json:"dir_rmse_bcl"`
+	DIR_RMSE_BCU         float64 `json:"dir_rmse_bcu"`
+}
+
+type TCST_TCMPR struct {
+	TOTAL          int     `json:"total"`
+	INDEX          int     `json:"index"`
+	LEVEL          string  `json:"level"`
+	WATCH_WARN     string  `json:"watch_warn"`
+	INITIALS       string  `json:"initials"`
+	ALAT           float64 `json:"alat"`
+	ALON           float64 `json:"alon"`
+	BLAT           float64 `json:"blat"`
+	BLON           float64 `json:"blon"`
+	TK_ERR         float64 `json:"tk_err"`
+	X_ERR          float64 `json:"x_err"`
+	Y_ERR          float64 `json:"y_err"`
+	ALTK_ERR       float64 `json:"altk_err"`
+	CRTK_ERR       float64 `json:"crtk_err"`
+	ADLAND         float64 `json:"adland"`
+	BDLAND         float64 `json:"bdland"`
+	AMSLP          float64 `json:"amslp"`
+	BMSLP          float64 `json:"bmslp"`
+	AMAX_WIND      float64 `json:"amax_wind"`
+	BMAX_WIND      float64 `json:"bmax_wind"`
+	AAL_WIND_34    float64 `json:"aal_wind_34"`
+	BAL_WIND_34    float64 `json:"bal_wind_34"`
+	ANE_WIND_34    float64 `json:"ane_wind_34"`
+	BNE_WIND_34    float64 `json:"bne_wind_34"`
+	ASE_WIND_34    float64 `json:"ase_wind_34"`
+	BSE_WIND_34    float64 `json:"bse_wind_34"`
+	ASW_WIND_34    float64 `json:"asw_wind_34"`
+	BSW_WIND_34    float64 `json:"bsw_wind_34"`
+	ANW_WIND_34    float64 `json:"anw_wind_34"`
+	BNW_WIND_34    float64 `json:"bnw_wind_34"`
+	AAL_WIND_50    float64 `json:"aal_wind_50"`
+	BAL_WIND_50    float64 `json:"bal_wind_50"`
+	ANE_WIND_50    float64 `json:"ane_wind_50"`
+	BNE_WIND_50    float64 `json:"bne_wind_50"`
+	ASE_WIND_50    float64 `json:"ase_wind_50"`
+	BSE_WIND_50    float64 `json:"bse_wind_50"`
+	ASW_WIND_50    float64 `json:"asw_wind_50"`
+	BSW_WIND_50    float64 `json:"bsw_wind_50"`
+	ANW_WIND_50    float64 `json:"anw_wind_50"`
+	BNW_WIND_50    float64 `json:"bnw_wind_50"`
+	AAL_WIND_64    float64 `json:"aal_wind_64"`
+	BAL_WIND_64    float64 `json:"bal_wind_64"`
+	ANE_WIND_64    float64 `json:"ane_wind_64"`
+	BNE_WIND_64    float64 `json:"bne_wind_64"`
+	ASE_WIND_64    float64 `json:"ase_wind_64"`
+	BSE_WIND_64    float64 `json:"bse_wind_64"`
+	ASW_WIND_64    float64 `json:"asw_wind_64"`
+	BSW_WIND_64    float64 `json:"bsw_wind_64"`
+	ANW_WIND_64    float64 `json:"anw_wind_64"`
+	BNW_WIND_64    float64 `json:"bnw_wind_64"`
+	ARADP          string  `json:"aradp"`
+	BRADP          float64 `json:"bradp"`
+	ARRP           int     `json:"arrp"`
+	BRRP           float64 `json:"brrp"`
+	AMRD           int     `json:"amrd"`
+	BMRD           float64 `json:"bmrd"`
+	AGUSTS         int     `json:"agusts"`
+	BGUSTS         float64 `json:"bgusts"`
+	AEYE           int     `json:"aeye"`
+	BEYE           float64 `json:"beye"`
+	ADIR           int     `json:"adir"`
+	BDIR           float64 `json:"bdir"`
+	ASPEED         int     `json:"aspeed"`
+	BSPEED         float64 `json:"bspeed"`
+	ADEPTH         int     `json:"adepth"`
+	BDEPTH         float64 `json:"bdepth"`
+	NUM_MEMBERS    float64 `json:"num_members"`
+	TRACK_SPREAD   float64 `json:"track_spread"`
+	TRACK_STDEV    float64 `json:"track_stdev"`
+	MSLP_STDEV     float64 `json:"mslp_stdev"`
+	MAX_WIND_STDEV float64 `json:"max_wind_stdev"`
+	INIT           int     `json:"init"`
+}
+
+type STAT_SEEPS_MPR struct {
+	OBS_SID  string  `json:"obs_sid"`
+	OBS_LAT  float64 `json:"obs_lat"`
+	OBS_LON  float64 `json:"obs_lon"`
+	FCST     float64 `json:"fcst"`
+	OBS      float64 `json:"obs"`
+	OBS_QC   string  `json:"obs_qc"`
+	FCST_CAT int     `json:"fcst_cat"`
+	OBS_CAT  int     `json:"obs_cat"`
+	P1       float64 `json:"p1"`
+	P2       float64 `json:"p2"`
+	T1       float64 `json:"t1"`
+	T2       float64 `json:"t2"`
+	SEEPS    float64 `json:"seeps"`
+}
+
+type STAT_PCT struct {
+	TOTAL  int                    `json:"total"`
+	THRESH map[string]interface{} `json:"thresh"`
+}
+
+type STAT_ECLV struct {
+	TOTAL       int                    `json:"total"`
+	BASER       float64                `json:"baser"`
+	VALUE_BASER int                    `json:"value_baser"`
+	PTS         map[string]interface{} `json:"pts"`
+}
+
+type STAT_SL1L2 struct {
+	TOTAL int     `json:"total"`
+	FBAR  float64 `json:"fbar"`
+	OBAR  float64 `json:"obar"`
+	FOBAR float64 `json:"fobar"`
+	FFBAR float64 `json:"ffbar"`
+	OOBAR float64 `json:"oobar"`
+	MAE   float64 `json:"mae"`
+}
+
+type STAT_SSVAR struct {
+	TOTAL       int     `json:"total"`
+	N_BIN       int     `json:"n_bin"`
+	BIN_I       int     `json:"bin_i"`
+	BIN_N       int     `json:"bin_n"`
+	VAR_MIN     float64 `json:"var_min"`
+	VAR_MAX     float64 `json:"var_max"`
+	VAR_MEAN    float64 `json:"var_mean"`
+	FBAR        float64 `json:"fbar"`
+	OBAR        float64 `json:"obar"`
+	FOBAR       float64 `json:"fobar"`
+	FFBAR       float64 `json:"ffbar"`
+	OOBAR       float64 `json:"oobar"`
+	FBAR_NCL    float64 `json:"fbar_ncl"`
+	FBAR_NCU    float64 `json:"fbar_ncu"`
+	FSTDEV      float64 `json:"fstdev"`
+	FSTDEV_NCL  float64 `json:"fstdev_ncl"`
+	FSTDEV_NCU  float64 `json:"fstdev_ncu"`
+	OBAR_NCL    float64 `json:"obar_ncl"`
+	OBAR_NCU    float64 `json:"obar_ncu"`
+	OSTDEV      float64 `json:"ostdev"`
+	OSTDEV_NCL  float64 `json:"ostdev_ncl"`
+	OSTDEV_NCU  float64 `json:"ostdev_ncu"`
+	PR_CORR     float64 `json:"pr_corr"`
+	PR_CORR_NCL float64 `json:"pr_corr_ncl"`
+	PR_CORR_NCU float64 `json:"pr_corr_ncu"`
+	ME          float64 `json:"me"`
+	ME_NCL      float64 `json:"me_ncl"`
+	ME_NCU      float64 `json:"me_ncu"`
+	ESTDEV      float64 `json:"estdev"`
+	ESTDEV_NCL  float64 `json:"estdev_ncl"`
+	ESTDEV_NCU  float64 `json:"estdev_ncu"`
+	MBIAS       float64 `json:"mbias"`
+	MSE         float64 `json:"mse"`
+	BCMSE       float64 `json:"bcmse"`
+	RMSE        float64 `json:"rmse"`
 }
 
 // fillStructure functions
-func (s *TCST_TCMPR) fill_TCST_TCMPR(fields []string) {
+func (s *STAT_SAL1L2) fill_STAT_SAL1L2(fields []string) {
 	dataLen := len(fields) - 1
 	i := -1
 	i++
@@ -4281,1025 +4281,27 @@ func (s *TCST_TCMPR) fill_TCST_TCMPR(fields []string) {
 	}
 	i++
 	if i <= dataLen {
-		s.INDEX, _ = strconv.Atoi(fields[1])
+		s.FABAR, _ = strconv.ParseFloat(fields[1], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.LEVEL = fields[2]
+		s.OABAR, _ = strconv.ParseFloat(fields[2], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.WATCH_WARN = fields[3]
+		s.FOABAR, _ = strconv.ParseFloat(fields[3], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.INITIALS = fields[4]
+		s.FFABAR, _ = strconv.ParseFloat(fields[4], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.ALAT, _ = strconv.ParseFloat(fields[5], 64)
+		s.OOABAR, _ = strconv.ParseFloat(fields[5], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.ALON, _ = strconv.ParseFloat(fields[6], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BLAT, _ = strconv.ParseFloat(fields[7], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BLON, _ = strconv.ParseFloat(fields[8], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.TK_ERR, _ = strconv.ParseFloat(fields[9], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.X_ERR, _ = strconv.ParseFloat(fields[10], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.Y_ERR, _ = strconv.ParseFloat(fields[11], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ALTK_ERR, _ = strconv.ParseFloat(fields[12], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CRTK_ERR, _ = strconv.ParseFloat(fields[13], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ADLAND, _ = strconv.ParseFloat(fields[14], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BDLAND, _ = strconv.ParseFloat(fields[15], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AMSLP, _ = strconv.ParseFloat(fields[16], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BMSLP, _ = strconv.ParseFloat(fields[17], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AMAX_WIND, _ = strconv.ParseFloat(fields[18], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BMAX_WIND, _ = strconv.ParseFloat(fields[19], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AAL_WIND_34, _ = strconv.ParseFloat(fields[20], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BAL_WIND_34, _ = strconv.ParseFloat(fields[21], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ANE_WIND_34, _ = strconv.ParseFloat(fields[22], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BNE_WIND_34, _ = strconv.ParseFloat(fields[23], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ASE_WIND_34, _ = strconv.ParseFloat(fields[24], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BSE_WIND_34, _ = strconv.ParseFloat(fields[25], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ASW_WIND_34, _ = strconv.ParseFloat(fields[26], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BSW_WIND_34, _ = strconv.ParseFloat(fields[27], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ANW_WIND_34, _ = strconv.ParseFloat(fields[28], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BNW_WIND_34, _ = strconv.ParseFloat(fields[29], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AAL_WIND_50, _ = strconv.ParseFloat(fields[30], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BAL_WIND_50, _ = strconv.ParseFloat(fields[31], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ANE_WIND_50, _ = strconv.ParseFloat(fields[32], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BNE_WIND_50, _ = strconv.ParseFloat(fields[33], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ASE_WIND_50, _ = strconv.ParseFloat(fields[34], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BSE_WIND_50, _ = strconv.ParseFloat(fields[35], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ASW_WIND_50, _ = strconv.ParseFloat(fields[36], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BSW_WIND_50, _ = strconv.ParseFloat(fields[37], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ANW_WIND_50, _ = strconv.ParseFloat(fields[38], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BNW_WIND_50, _ = strconv.ParseFloat(fields[39], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AAL_WIND_64, _ = strconv.ParseFloat(fields[40], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BAL_WIND_64, _ = strconv.ParseFloat(fields[41], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ANE_WIND_64, _ = strconv.ParseFloat(fields[42], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BNE_WIND_64, _ = strconv.ParseFloat(fields[43], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ASE_WIND_64, _ = strconv.ParseFloat(fields[44], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BSE_WIND_64, _ = strconv.ParseFloat(fields[45], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ASW_WIND_64, _ = strconv.ParseFloat(fields[46], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BSW_WIND_64, _ = strconv.ParseFloat(fields[47], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ANW_WIND_64, _ = strconv.ParseFloat(fields[48], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BNW_WIND_64, _ = strconv.ParseFloat(fields[49], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ARADP = fields[50]
-	}
-	i++
-	if i <= dataLen {
-		s.BRADP, _ = strconv.ParseFloat(fields[51], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ARRP, _ = strconv.Atoi(fields[52])
-	}
-	i++
-	if i <= dataLen {
-		s.BRRP, _ = strconv.ParseFloat(fields[53], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AMRD, _ = strconv.Atoi(fields[54])
-	}
-	i++
-	if i <= dataLen {
-		s.BMRD, _ = strconv.ParseFloat(fields[55], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AGUSTS, _ = strconv.Atoi(fields[56])
-	}
-	i++
-	if i <= dataLen {
-		s.BGUSTS, _ = strconv.ParseFloat(fields[57], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AEYE, _ = strconv.Atoi(fields[58])
-	}
-	i++
-	if i <= dataLen {
-		s.BEYE, _ = strconv.ParseFloat(fields[59], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ADIR, _ = strconv.Atoi(fields[60])
-	}
-	i++
-	if i <= dataLen {
-		s.BDIR, _ = strconv.ParseFloat(fields[61], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ASPEED, _ = strconv.Atoi(fields[62])
-	}
-	i++
-	if i <= dataLen {
-		s.BSPEED, _ = strconv.ParseFloat(fields[63], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ADEPTH, _ = strconv.Atoi(fields[64])
-	}
-	i++
-	if i <= dataLen {
-		s.BDEPTH, _ = strconv.ParseFloat(fields[65], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.NUM_MEMBERS, _ = strconv.ParseFloat(fields[66], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.TRACK_SPREAD, _ = strconv.ParseFloat(fields[67], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.TRACK_STDEV, _ = strconv.ParseFloat(fields[68], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.MSLP_STDEV, _ = strconv.ParseFloat(fields[69], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.MAX_WIND_STDEV, _ = strconv.ParseFloat(fields[70], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INIT, _ = strconv.Atoi(fields[71])
-	}
-}
-
-func (s *STAT_FHO) fill_STAT_FHO(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen {
-		s.F_RATE, _ = strconv.ParseFloat(fields[1], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.H_RATE, _ = strconv.ParseFloat(fields[2], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.O_RATE, _ = strconv.ParseFloat(fields[3], 64)
-	}
-}
-
-func (s *STAT_ORANK) fill_STAT_ORANK(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen {
-		s.INDEX, _ = strconv.Atoi(fields[1])
-	}
-	i++
-	if i <= dataLen {
-		s.OBS_SID = fields[2]
-	}
-	i++
-	if i <= dataLen {
-		s.OBS_LAT, _ = strconv.ParseFloat(fields[3], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OBS_LON, _ = strconv.ParseFloat(fields[4], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OBS_LVL, _ = strconv.ParseFloat(fields[5], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OBS_ELV, _ = strconv.ParseFloat(fields[6], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OBS, _ = strconv.ParseFloat(fields[7], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.PIT, _ = strconv.ParseFloat(fields[8], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.RANK, _ = strconv.Atoi(fields[9])
-	}
-	i++
-	if i <= dataLen {
-		s.N_ENS_VLD, _ = strconv.Atoi(fields[10])
-	}
-	i++
-	if i <= dataLen { // the first field of the repeating fields is the TOTAL, the second field is the 1st dimenSion of the 1st sequence (there might be only one sequence)
-		var value interface{}
-		count, err := strconv.Atoi(fields[11])
-		if err != nil {
-			count = 0
-		}
-		keyPrefixes := []string{"ENS_"}
-		s.ENS = make(map[string]interface{})
-		for group := 1; group <= count; group++ {
-			for index := 12; index <= len(keyPrefixes); index++ {
-				key := fmt.Sprintf("%s_%d", keyPrefixes[index-1], index)
-				if index > len(fields) { // sometimes the data line is truncated - we will set expected data to "NA"
-					value = "NA"
-				} else {
-					value, err = strconv.Atoi(fields[index])
-					if err != nil { // sometimes there can be these NA values in the data, which will be left out of json
-						value = "NA"
-					}
-				}
-				s.ENS[key] = value
-			}
-		}
-	}
-	i++
-	if i <= dataLen {
-		s.OBS_QC = fields[13]
-	}
-	i++
-	if i <= dataLen {
-		s.ENS_MEAN, _ = strconv.Atoi(fields[14])
-	}
-	i++
-	if i <= dataLen {
-		s.OBS_CLIMO_MEAN, _ = strconv.ParseFloat(fields[15], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SPREAD, _ = strconv.ParseFloat(fields[16], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ENS_MEAN_OERR, _ = strconv.Atoi(fields[17])
-	}
-	i++
-	if i <= dataLen {
-		s.SPREAD_OERR, _ = strconv.ParseFloat(fields[18], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SPREAD_PLUS_OERR, _ = strconv.ParseFloat(fields[19], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OBS_CLIMO_STDEV, _ = strconv.ParseFloat(fields[20], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FCST_CLIMO_MEAN, _ = strconv.ParseFloat(fields[21], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FCST_CLIMO_STDEV, _ = strconv.ParseFloat(fields[22], 64)
-	}
-}
-
-func (s *STAT_PHIST) fill_STAT_PHIST(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen {
-		s.BIN_SIZE, _ = strconv.Atoi(fields[1])
-	}
-	i++
-	if i <= dataLen { // the first field of the repeating fields is the TOTAL, the second field is the 1st dimenSion of the 1st sequence (there might be only one sequence)
-		var value interface{}
-		count, err := strconv.Atoi(fields[2])
-		if err != nil {
-			count = 0
-		}
-		keyPrefixes := []string{"BIN_"}
-		s.BIN = make(map[string]interface{})
-		for group := 1; group <= count; group++ {
-			for index := 3; index <= len(keyPrefixes); index++ {
-				key := fmt.Sprintf("%s_%d", keyPrefixes[index-1], index)
-				if index > len(fields) { // sometimes the data line is truncated - we will set expected data to "NA"
-					value = "NA"
-				} else {
-					value, err = strconv.Atoi(fields[index])
-					if err != nil { // sometimes there can be these NA values in the data, which will be left out of json
-						value = "NA"
-					}
-				}
-				s.BIN[key] = value
-			}
-		}
-	}
-}
-
-func (s *STAT_NBRCNT) fill_STAT_NBRCNT(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen {
-		s.FBS, _ = strconv.ParseFloat(fields[1], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FBS_BCL, _ = strconv.ParseFloat(fields[2], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FBS_BCU, _ = strconv.ParseFloat(fields[3], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FSS, _ = strconv.ParseFloat(fields[4], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FSS_BCL, _ = strconv.ParseFloat(fields[5], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FSS_BCU, _ = strconv.ParseFloat(fields[6], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AFSS, _ = strconv.ParseFloat(fields[7], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AFSS_BCL, _ = strconv.ParseFloat(fields[8], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AFSS_BCU, _ = strconv.ParseFloat(fields[9], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.UFSS, _ = strconv.ParseFloat(fields[10], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.UFSS_BCL, _ = strconv.ParseFloat(fields[11], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.UFSS_BCU, _ = strconv.ParseFloat(fields[12], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.F_RATE, _ = strconv.ParseFloat(fields[13], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.F_RATE_BCL, _ = strconv.ParseFloat(fields[14], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.F_RATE_BCU, _ = strconv.ParseFloat(fields[15], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.O_RATE, _ = strconv.ParseFloat(fields[16], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.O_RATE_BCL, _ = strconv.ParseFloat(fields[17], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.O_RATE_BCU, _ = strconv.ParseFloat(fields[18], 64)
-	}
-}
-
-func (s *MODE_CTS) fill_MODE_CTS(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.FIELD = fields[0]
-	}
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[1])
-	}
-	i++
-	if i <= dataLen {
-		s.FY_OY, _ = strconv.ParseFloat(fields[2], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FY_ON, _ = strconv.ParseFloat(fields[3], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FN_OY, _ = strconv.ParseFloat(fields[4], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FN_ON, _ = strconv.ParseFloat(fields[5], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BASER, _ = strconv.ParseFloat(fields[6], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FMEAN, _ = strconv.ParseFloat(fields[7], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ACC, _ = strconv.ParseFloat(fields[8], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FBIAS, _ = strconv.ParseFloat(fields[9], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.PODY, _ = strconv.ParseFloat(fields[10], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.PODN, _ = strconv.ParseFloat(fields[11], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.POFD, _ = strconv.ParseFloat(fields[12], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FAR, _ = strconv.ParseFloat(fields[13], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CSI, _ = strconv.ParseFloat(fields[14], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.GSS, _ = strconv.ParseFloat(fields[15], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HK, _ = strconv.ParseFloat(fields[16], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HSS, _ = strconv.ParseFloat(fields[17], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ODDS, _ = strconv.ParseFloat(fields[18], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.LODDS, _ = strconv.ParseFloat(fields[19], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ORSS, _ = strconv.ParseFloat(fields[20], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.EDS, _ = strconv.ParseFloat(fields[21], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SEDS, _ = strconv.ParseFloat(fields[22], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.EDI, _ = strconv.ParseFloat(fields[23], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SEDI, _ = strconv.ParseFloat(fields[24], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BAGSS, _ = strconv.ParseFloat(fields[25], 64)
-	}
-}
-
-func (s *STAT_MPR) fill_STAT_MPR(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen {
-		s.INDEX, _ = strconv.Atoi(fields[1])
-	}
-	i++
-	if i <= dataLen {
-		s.OBS_SID = fields[2]
-	}
-	i++
-	if i <= dataLen {
-		s.OBS_LAT, _ = strconv.ParseFloat(fields[3], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OBS_LON, _ = strconv.ParseFloat(fields[4], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OBS_LVL, _ = strconv.ParseFloat(fields[5], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OBS_ELV, _ = strconv.ParseFloat(fields[6], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FCST, _ = strconv.ParseFloat(fields[7], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OBS, _ = strconv.ParseFloat(fields[8], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OBS_QC = fields[9]
-	}
-	i++
-	if i <= dataLen {
-		s.OBS_CLIMO_MEAN, _ = strconv.ParseFloat(fields[10], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OBS_CLIMO_STDEV, _ = strconv.ParseFloat(fields[11], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OBS_CLIMO_CDF, _ = strconv.ParseFloat(fields[12], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FCST_CLIMO_MEAN, _ = strconv.ParseFloat(fields[13], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FCST_CLIMO_STDEV, _ = strconv.ParseFloat(fields[14], 64)
-	}
-}
-
-func (s *STAT_PSTD) fill_STAT_PSTD(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen { // the first field of the repeating fields is the TOTAL, the second field is the 1st dimenSion of the 1st sequence (there might be only one sequence)
-		var value interface{}
-		count, err := strconv.Atoi(fields[1])
-		if err != nil {
-			count = 0
-		}
-		keyPrefixes := []string{"THRESH_"}
-		s.THRESH = make(map[string]interface{})
-		for group := 1; group <= count; group++ {
-			for index := 2; index <= len(keyPrefixes); index++ {
-				key := fmt.Sprintf("%s_%d", keyPrefixes[index-1], index)
-				if index > len(fields) { // sometimes the data line is truncated - we will set expected data to "NA"
-					value = "NA"
-				} else {
-					value, err = strconv.ParseFloat(fields[index], 64)
-					if err != nil { // sometimes there can be these NA values in the data, which will be left out of json
-						value = "NA"
-					}
-				}
-				s.THRESH[key] = value
-			}
-		}
-	}
-	i++
-	if i <= dataLen {
-		s.BASER_NCL, _ = strconv.ParseFloat(fields[3], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BASER_NCU, _ = strconv.ParseFloat(fields[4], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.RELIABILITY, _ = strconv.ParseFloat(fields[5], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.RESOLUTION, _ = strconv.ParseFloat(fields[6], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.UNCERTAINTY, _ = strconv.ParseFloat(fields[7], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ROC_AUC, _ = strconv.ParseFloat(fields[8], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BRIER, _ = strconv.ParseFloat(fields[9], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BRIER_NCL, _ = strconv.ParseFloat(fields[10], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BRIER_NCU, _ = strconv.ParseFloat(fields[11], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BRIERCL, _ = strconv.ParseFloat(fields[12], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BRIERCL_NCL, _ = strconv.ParseFloat(fields[13], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BRIERCL_NCU, _ = strconv.ParseFloat(fields[14], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BSS, _ = strconv.ParseFloat(fields[15], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BSS_SMPL, _ = strconv.ParseFloat(fields[16], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.THRESH_I, _ = strconv.Atoi(fields[17])
-	}
-}
-
-func (s *STAT_ECLV) fill_STAT_ECLV(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen {
-		s.BASER, _ = strconv.ParseFloat(fields[1], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.VALUE_BASER, _ = strconv.Atoi(fields[2])
-	}
-	i++
-	if i <= dataLen { // the first field of the repeating fields is the TOTAL, the second field is the 1st dimenSion of the 1st sequence (there might be only one sequence)
-		var value interface{}
-		count, err := strconv.Atoi(fields[3])
-		if err != nil {
-			count = 0
-		}
-		keyPrefixes := []string{"CL_", "VALUE_"}
-		s.PTS = make(map[string]interface{})
-		for group := 1; group <= count; group++ {
-			for index := 4; index <= len(keyPrefixes); index++ {
-				key := fmt.Sprintf("%s_%d", keyPrefixes[index-1], index)
-				if index > len(fields) { // sometimes the data line is truncated - we will set expected data to "NA"
-					value = "NA"
-				} else {
-					value, err = strconv.ParseFloat(fields[index], 64)
-					if err != nil { // sometimes there can be these NA values in the data, which will be left out of json
-						value = "NA"
-					}
-				}
-				s.PTS[key] = value
-			}
-		}
-	}
-}
-
-func (s *STAT_RHIST) fill_STAT_RHIST(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen { // the first field of the repeating fields is the TOTAL, the second field is the 1st dimenSion of the 1st sequence (there might be only one sequence)
-		var value interface{}
-		count, err := strconv.Atoi(fields[1])
-		if err != nil {
-			count = 0
-		}
-		keyPrefixes := []string{"RANK_"}
-		s.RANK = make(map[string]interface{})
-		for group := 1; group <= count; group++ {
-			for index := 2; index <= len(keyPrefixes); index++ {
-				key := fmt.Sprintf("%s_%d", keyPrefixes[index-1], index)
-				if index > len(fields) { // sometimes the data line is truncated - we will set expected data to "NA"
-					value = "NA"
-				} else {
-					value, err = strconv.Atoi(fields[index])
-					if err != nil { // sometimes there can be these NA values in the data, which will be left out of json
-						value = "NA"
-					}
-				}
-				s.RANK[key] = value
-			}
-		}
-	}
-}
-
-func (s *STAT_SSVAR) fill_STAT_SSVAR(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen {
-		s.N_BIN, _ = strconv.Atoi(fields[1])
-	}
-	i++
-	if i <= dataLen {
-		s.BIN_I, _ = strconv.Atoi(fields[2])
-	}
-	i++
-	if i <= dataLen {
-		s.BIN_N, _ = strconv.Atoi(fields[3])
-	}
-	i++
-	if i <= dataLen {
-		s.VAR_MIN, _ = strconv.ParseFloat(fields[4], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.VAR_MAX, _ = strconv.ParseFloat(fields[5], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.VAR_MEAN, _ = strconv.ParseFloat(fields[6], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FBAR, _ = strconv.ParseFloat(fields[7], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OBAR, _ = strconv.ParseFloat(fields[8], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FOBAR, _ = strconv.ParseFloat(fields[9], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FFBAR, _ = strconv.ParseFloat(fields[10], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OOBAR, _ = strconv.ParseFloat(fields[11], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FBAR_NCL, _ = strconv.ParseFloat(fields[12], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FBAR_NCU, _ = strconv.ParseFloat(fields[13], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FSTDEV, _ = strconv.ParseFloat(fields[14], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FSTDEV_NCL, _ = strconv.ParseFloat(fields[15], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FSTDEV_NCU, _ = strconv.ParseFloat(fields[16], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OBAR_NCL, _ = strconv.ParseFloat(fields[17], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OBAR_NCU, _ = strconv.ParseFloat(fields[18], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OSTDEV, _ = strconv.ParseFloat(fields[19], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OSTDEV_NCL, _ = strconv.ParseFloat(fields[20], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OSTDEV_NCU, _ = strconv.ParseFloat(fields[21], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.PR_CORR, _ = strconv.ParseFloat(fields[22], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.PR_CORR_NCL, _ = strconv.ParseFloat(fields[23], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.PR_CORR_NCU, _ = strconv.ParseFloat(fields[24], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ME, _ = strconv.ParseFloat(fields[25], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ME_NCL, _ = strconv.ParseFloat(fields[26], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ME_NCU, _ = strconv.ParseFloat(fields[27], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ESTDEV, _ = strconv.ParseFloat(fields[28], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ESTDEV_NCL, _ = strconv.ParseFloat(fields[29], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ESTDEV_NCU, _ = strconv.ParseFloat(fields[30], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.MBIAS, _ = strconv.ParseFloat(fields[31], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.MSE, _ = strconv.ParseFloat(fields[32], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BCMSE, _ = strconv.ParseFloat(fields[33], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.RMSE, _ = strconv.ParseFloat(fields[34], 64)
+		s.MAE, _ = strconv.ParseFloat(fields[6], 64)
 	}
 }
 
@@ -5612,7 +4614,7 @@ func (s *STAT_VCNT) fill_STAT_VCNT(fields []string) {
 	}
 }
 
-func (s *MTD_3DPAIR) fill_MTD_3DPAIR(fields []string) {
+func (s *MODE_OBJ) fill_MODE_OBJ(fields []string) {
 	dataLen := len(fields) - 1
 	i := -1
 	i++
@@ -5625,47 +4627,1428 @@ func (s *MTD_3DPAIR) fill_MTD_3DPAIR(fields []string) {
 	}
 	i++
 	if i <= dataLen {
-		s.SPACE_CENTROID_DIST, _ = strconv.ParseFloat(fields[2], 64)
+		s.CENTROID_X, _ = strconv.ParseFloat(fields[2], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.TIME_CENTROID_DELTA, _ = strconv.ParseFloat(fields[3], 64)
+		s.CENTROID_Y, _ = strconv.ParseFloat(fields[3], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.AXIS_DIFF, _ = strconv.ParseFloat(fields[4], 64)
+		s.CENTROID_LAT, _ = strconv.ParseFloat(fields[4], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.SPEED_DELTA, _ = strconv.ParseFloat(fields[5], 64)
+		s.CENTROID_LON, _ = strconv.ParseFloat(fields[5], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.DIRECTION_DIFF, _ = strconv.ParseFloat(fields[6], 64)
+		s.AXIS_ANG, _ = strconv.ParseFloat(fields[6], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.VOLUME_RATIO, _ = strconv.ParseFloat(fields[7], 64)
+		s.LENGTH, _ = strconv.ParseFloat(fields[7], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.START_TIME_DELTA, _ = strconv.Atoi(fields[8])
+		s.WIDTH, _ = strconv.ParseFloat(fields[8], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.END_TIME_DELTA, _ = strconv.Atoi(fields[9])
+		s.AREA, _ = strconv.Atoi(fields[9])
 	}
 	i++
 	if i <= dataLen {
-		s.INTERSECTION_VOLUME, _ = strconv.ParseFloat(fields[10], 64)
+		s.AREA_THRESH, _ = strconv.Atoi(fields[10])
 	}
 	i++
 	if i <= dataLen {
-		s.DURATION_DIFF, _ = strconv.ParseFloat(fields[11], 64)
+		s.CURVATURE, _ = strconv.ParseFloat(fields[11], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.INTEREST, _ = strconv.ParseFloat(fields[12], 64)
+		s.CURVATURE_X, _ = strconv.ParseFloat(fields[12], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CURVATURE_Y, _ = strconv.ParseFloat(fields[13], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.COMPLEXITY, _ = strconv.ParseFloat(fields[14], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTENSITY_10, _ = strconv.ParseFloat(fields[15], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTENSITY_25, _ = strconv.ParseFloat(fields[16], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTENSITY_50, _ = strconv.ParseFloat(fields[17], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTENSITY_75, _ = strconv.ParseFloat(fields[18], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTENSITY_90, _ = strconv.ParseFloat(fields[19], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTENSITY_USER, _ = strconv.ParseFloat(fields[20], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTENSITY_SUM, _ = strconv.ParseFloat(fields[21], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CENTROID_DIST, _ = strconv.ParseFloat(fields[22], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BOUNDARY_DIST, _ = strconv.ParseFloat(fields[23], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CONVEX_HULL_DIST, _ = strconv.ParseFloat(fields[24], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ANGLE_DIFF, _ = strconv.ParseFloat(fields[25], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ASPECT_DIFF, _ = strconv.ParseFloat(fields[26], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.AREA_RATIO, _ = strconv.ParseFloat(fields[27], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTERSECTION_AREA, _ = strconv.ParseFloat(fields[28], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.UNION_AREA, _ = strconv.ParseFloat(fields[29], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SYMMETRIC_DIFF, _ = strconv.ParseFloat(fields[30], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTERSECTION_OVER_AREA, _ = strconv.ParseFloat(fields[31], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CURVATURE_RATIO, _ = strconv.ParseFloat(fields[32], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.COMPLEXITY_RATIO, _ = strconv.ParseFloat(fields[33], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PERCENTILE_INTENSITY_RATIO, _ = strconv.ParseFloat(fields[34], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTEREST, _ = strconv.ParseFloat(fields[35], 64)
+	}
+}
+
+func (s *STAT_ISC) fill_STAT_ISC(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen {
+		s.TILE_DIM, _ = strconv.Atoi(fields[1])
+	}
+	i++
+	if i <= dataLen {
+		s.TILE_XLL, _ = strconv.Atoi(fields[2])
+	}
+	i++
+	if i <= dataLen {
+		s.TILE_YLL, _ = strconv.Atoi(fields[3])
+	}
+	i++
+	if i <= dataLen {
+		s.NSCALE, _ = strconv.Atoi(fields[4])
+	}
+	i++
+	if i <= dataLen {
+		s.ISCALE, _ = strconv.Atoi(fields[5])
+	}
+	i++
+	if i <= dataLen {
+		s.MSE, _ = strconv.ParseFloat(fields[6], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ISC, _ = strconv.ParseFloat(fields[7], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FENERGY2, _ = strconv.ParseFloat(fields[8], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OENERGY2, _ = strconv.ParseFloat(fields[9], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BASER, _ = strconv.ParseFloat(fields[10], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FBIAS, _ = strconv.ParseFloat(fields[11], 64)
+	}
+}
+
+func (s *STAT_NBRCTC) fill_STAT_NBRCTC(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen {
+		s.FY_OY, _ = strconv.ParseFloat(fields[1], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FY_ON, _ = strconv.ParseFloat(fields[2], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FN_OY, _ = strconv.ParseFloat(fields[3], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FN_ON, _ = strconv.ParseFloat(fields[4], 64)
+	}
+}
+
+func (s *STAT_DMAP) fill_STAT_DMAP(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen {
+		s.FY, _ = strconv.Atoi(fields[1])
+	}
+	i++
+	if i <= dataLen {
+		s.OY, _ = strconv.Atoi(fields[2])
+	}
+	i++
+	if i <= dataLen {
+		s.FBIAS, _ = strconv.ParseFloat(fields[3], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BADDELEY, _ = strconv.ParseFloat(fields[4], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HAUSDORFF, _ = strconv.ParseFloat(fields[5], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.MED_FO, _ = strconv.ParseFloat(fields[6], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.MED_OF, _ = strconv.ParseFloat(fields[7], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.MED_MIN, _ = strconv.ParseFloat(fields[8], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.MED_MAX, _ = strconv.ParseFloat(fields[9], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.MED_MEAN, _ = strconv.ParseFloat(fields[10], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FOM_FO, _ = strconv.ParseFloat(fields[11], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FOM_OF, _ = strconv.ParseFloat(fields[12], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FOM_MIN, _ = strconv.ParseFloat(fields[13], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FOM_MAX, _ = strconv.ParseFloat(fields[14], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FOM_MEAN, _ = strconv.ParseFloat(fields[15], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ZHU_FO, _ = strconv.ParseFloat(fields[16], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ZHU_OF, _ = strconv.ParseFloat(fields[17], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ZHU_MIN, _ = strconv.ParseFloat(fields[18], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ZHU_MAX, _ = strconv.ParseFloat(fields[19], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ZHU_MEAN, _ = strconv.ParseFloat(fields[20], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.G, _ = strconv.ParseFloat(fields[21], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.GBETA, _ = strconv.ParseFloat(fields[22], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BETA_VALUE, _ = strconv.ParseFloat(fields[23], 64)
+	}
+}
+
+func (s *STAT_SEEPS_MPR) fill_STAT_SEEPS_MPR(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.OBS_SID = fields[0]
+	}
+	i++
+	if i <= dataLen {
+		s.OBS_LAT, _ = strconv.ParseFloat(fields[1], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OBS_LON, _ = strconv.ParseFloat(fields[2], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FCST, _ = strconv.ParseFloat(fields[3], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OBS, _ = strconv.ParseFloat(fields[4], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OBS_QC = fields[5]
+	}
+	i++
+	if i <= dataLen {
+		s.FCST_CAT, _ = strconv.Atoi(fields[6])
+	}
+	i++
+	if i <= dataLen {
+		s.OBS_CAT, _ = strconv.Atoi(fields[7])
+	}
+	i++
+	if i <= dataLen {
+		s.P1, _ = strconv.ParseFloat(fields[8], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.P2, _ = strconv.ParseFloat(fields[9], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.T1, _ = strconv.ParseFloat(fields[10], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.T2, _ = strconv.ParseFloat(fields[11], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SEEPS, _ = strconv.ParseFloat(fields[12], 64)
+	}
+}
+
+func (s *STAT_GENMPR) fill_STAT_GENMPR(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen {
+		s.INDEX, _ = strconv.Atoi(fields[1])
+	}
+	i++
+	if i <= dataLen {
+		s.STORM_ID = fields[2]
+	}
+	i++
+	if i <= dataLen {
+		s.PROB_LEAD, _ = strconv.ParseFloat(fields[3], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PROB_VAL, _ = strconv.ParseFloat(fields[4], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.AGEN_INIT = fields[5]
+	}
+	i++
+	if i <= dataLen {
+		s.AGEN_FHR = fields[6]
+	}
+	i++
+	if i <= dataLen {
+		s.AGEN_LAT, _ = strconv.ParseFloat(fields[7], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.AGEN_LON, _ = strconv.ParseFloat(fields[8], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.AGEN_DLAND, _ = strconv.ParseFloat(fields[9], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BGEN_LAT, _ = strconv.ParseFloat(fields[10], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BGEN_LON, _ = strconv.ParseFloat(fields[11], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BGEN_DLAND, _ = strconv.ParseFloat(fields[12], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.GEN_DIST, _ = strconv.ParseFloat(fields[13], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.GEN_TDIFF = fields[14]
+	}
+	i++
+	if i <= dataLen {
+		s.INIT_TDIFF = fields[15]
+	}
+	i++
+	if i <= dataLen {
+		s.DEV_CAT = fields[16]
+	}
+	i++
+	if i <= dataLen {
+		s.OPS_CAT = fields[17]
+	}
+}
+
+func (s *STAT_ECLV) fill_STAT_ECLV(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen {
+		s.BASER, _ = strconv.ParseFloat(fields[1], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.VALUE_BASER, _ = strconv.Atoi(fields[2])
+	}
+	i++
+	if i <= dataLen { // the first field of the repeating fields is the TOTAL, the second field is the 1st dimenSion of the 1st sequence (there might be only one sequence)
+		var value interface{}
+		count, err := strconv.Atoi(fields[3])
+		if err != nil {
+			count = 0
+		}
+		keyPrefixes := []string{"CL_", "VALUE_"}
+		s.PTS = make(map[string]interface{})
+		for group := 1; group <= count; group++ {
+			for index := 4; index <= len(keyPrefixes); index++ {
+				key := fmt.Sprintf("%s_%d", keyPrefixes[index-1], index)
+				if index > len(fields) { // sometimes the data line is truncated - we will set expected data to "NA"
+					value = "NA"
+				} else {
+					value, err = strconv.ParseFloat(fields[index], 64)
+					if err != nil { // sometimes there can be these NA values in the data, which will be left out of json
+						value = "NA"
+					}
+				}
+				s.PTS[key] = value
+			}
+		}
+	}
+}
+
+func (s *MTD_2DSINGLE) fill_MTD_2DSINGLE(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.OBJECT_ID = fields[0]
+	}
+	i++
+	if i <= dataLen {
+		s.OBJECT_CAT = fields[1]
+	}
+	i++
+	if i <= dataLen {
+		s.TIME_INDEX, _ = strconv.Atoi(fields[2])
+	}
+	i++
+	if i <= dataLen {
+		s.AREA, _ = strconv.Atoi(fields[3])
+	}
+	i++
+	if i <= dataLen {
+		s.CENTROID_X, _ = strconv.ParseFloat(fields[4], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CENTROID_Y, _ = strconv.ParseFloat(fields[5], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CENTROID_LAT, _ = strconv.ParseFloat(fields[6], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CENTROID_LON, _ = strconv.ParseFloat(fields[7], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.AXIS_ANG, _ = strconv.ParseFloat(fields[8], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTENSITY_10, _ = strconv.ParseFloat(fields[9], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTENSITY_25, _ = strconv.ParseFloat(fields[10], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTENSITY_50, _ = strconv.ParseFloat(fields[11], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTENSITY_75, _ = strconv.ParseFloat(fields[12], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTENSITY_90, _ = strconv.ParseFloat(fields[13], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTENSITY_USER, _ = strconv.ParseFloat(fields[14], 64)
+	}
+}
+
+func (s *STAT_FHO) fill_STAT_FHO(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen {
+		s.F_RATE, _ = strconv.ParseFloat(fields[1], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.H_RATE, _ = strconv.ParseFloat(fields[2], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.O_RATE, _ = strconv.ParseFloat(fields[3], 64)
+	}
+}
+
+func (s *STAT_SEEPS) fill_STAT_SEEPS(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen {
+		s.ODFL, _ = strconv.ParseFloat(fields[1], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ODFH, _ = strconv.ParseFloat(fields[2], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OLFD, _ = strconv.ParseFloat(fields[3], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OLFH, _ = strconv.ParseFloat(fields[4], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OHFD, _ = strconv.ParseFloat(fields[5], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OHFL, _ = strconv.ParseFloat(fields[6], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PF1, _ = strconv.ParseFloat(fields[7], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PF2, _ = strconv.ParseFloat(fields[8], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PF3, _ = strconv.ParseFloat(fields[9], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PV1, _ = strconv.ParseFloat(fields[10], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PV2, _ = strconv.ParseFloat(fields[11], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PV3, _ = strconv.ParseFloat(fields[12], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.MEAN_FCST, _ = strconv.ParseFloat(fields[13], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.MEAN_OBS, _ = strconv.ParseFloat(fields[14], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SEEPS, _ = strconv.ParseFloat(fields[15], 64)
+	}
+}
+
+func (s *STAT_PCT) fill_STAT_PCT(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen { // the first field of the repeating fields is the TOTAL, the second field is the 1st dimenSion of the 1st sequence (there might be only one sequence)
+		var value interface{}
+		count, err := strconv.Atoi(fields[1])
+		if err != nil {
+			count = 0
+		}
+		keyPrefixes := []string{"THRESH_", "OY_", "ON_"}
+		s.THRESH = make(map[string]interface{})
+		for group := 1; group <= count; group++ {
+			for index := 2; index <= len(keyPrefixes); index++ {
+				key := fmt.Sprintf("%s_%d", keyPrefixes[index-1], index)
+				if index > len(fields) { // sometimes the data line is truncated - we will set expected data to "NA"
+					value = "NA"
+				} else {
+					value, err = strconv.ParseFloat(fields[index], 64)
+					if err != nil { // sometimes there can be these NA values in the data, which will be left out of json
+						value = "NA"
+					}
+				}
+				s.THRESH[key] = value
+			}
+		}
+	}
+}
+
+func (s *STAT_PHIST) fill_STAT_PHIST(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen {
+		s.BIN_SIZE, _ = strconv.Atoi(fields[1])
+	}
+	i++
+	if i <= dataLen { // the first field of the repeating fields is the TOTAL, the second field is the 1st dimenSion of the 1st sequence (there might be only one sequence)
+		var value interface{}
+		count, err := strconv.Atoi(fields[2])
+		if err != nil {
+			count = 0
+		}
+		keyPrefixes := []string{"BIN_"}
+		s.BIN = make(map[string]interface{})
+		for group := 1; group <= count; group++ {
+			for index := 3; index <= len(keyPrefixes); index++ {
+				key := fmt.Sprintf("%s_%d", keyPrefixes[index-1], index)
+				if index > len(fields) { // sometimes the data line is truncated - we will set expected data to "NA"
+					value = "NA"
+				} else {
+					value, err = strconv.Atoi(fields[index])
+					if err != nil { // sometimes there can be these NA values in the data, which will be left out of json
+						value = "NA"
+					}
+				}
+				s.BIN[key] = value
+			}
+		}
+	}
+}
+
+func (s *STAT_VL1L2) fill_STAT_VL1L2(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen {
+		s.UFBAR, _ = strconv.ParseFloat(fields[1], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.VFBAR, _ = strconv.ParseFloat(fields[2], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.UOBAR, _ = strconv.ParseFloat(fields[3], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.VOBAR, _ = strconv.ParseFloat(fields[4], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.UVFOBAR, _ = strconv.ParseFloat(fields[5], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.UVFFBAR, _ = strconv.ParseFloat(fields[6], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.UVOOBAR, _ = strconv.ParseFloat(fields[7], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.F_SPEED_BAR, _ = strconv.ParseFloat(fields[8], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.O_SPEED_BAR, _ = strconv.ParseFloat(fields[9], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.TOTAL_DIR, _ = strconv.ParseFloat(fields[10], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.DIR_ME, _ = strconv.ParseFloat(fields[11], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.DIR_MAE, _ = strconv.ParseFloat(fields[12], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.DIR_MSE, _ = strconv.ParseFloat(fields[13], 64)
+	}
+}
+
+func (s *STAT_SSIDX) fill_STAT_SSIDX(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.FCST_MODEL = fields[0]
+	}
+	i++
+	if i <= dataLen {
+		s.REF_MODEL = fields[1]
+	}
+	i++
+	if i <= dataLen {
+		s.N_INIT, _ = strconv.Atoi(fields[2])
+	}
+	i++
+	if i <= dataLen {
+		s.N_TERM, _ = strconv.Atoi(fields[3])
+	}
+	i++
+	if i <= dataLen {
+		s.N_VLD, _ = strconv.Atoi(fields[4])
+	}
+	i++
+	if i <= dataLen {
+		s.SS_INDEX, _ = strconv.ParseFloat(fields[5], 64)
+	}
+}
+
+func (s *STAT_MPR) fill_STAT_MPR(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen {
+		s.INDEX, _ = strconv.Atoi(fields[1])
+	}
+	i++
+	if i <= dataLen {
+		s.OBS_SID = fields[2]
+	}
+	i++
+	if i <= dataLen {
+		s.OBS_LAT, _ = strconv.ParseFloat(fields[3], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OBS_LON, _ = strconv.ParseFloat(fields[4], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OBS_LVL, _ = strconv.ParseFloat(fields[5], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OBS_ELV, _ = strconv.ParseFloat(fields[6], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FCST, _ = strconv.ParseFloat(fields[7], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OBS, _ = strconv.ParseFloat(fields[8], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OBS_QC = fields[9]
+	}
+	i++
+	if i <= dataLen {
+		s.OBS_CLIMO_MEAN, _ = strconv.ParseFloat(fields[10], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OBS_CLIMO_STDEV, _ = strconv.ParseFloat(fields[11], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OBS_CLIMO_CDF, _ = strconv.ParseFloat(fields[12], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FCST_CLIMO_MEAN, _ = strconv.ParseFloat(fields[13], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FCST_CLIMO_STDEV, _ = strconv.ParseFloat(fields[14], 64)
+	}
+}
+
+func (s *STAT_NBRCTS) fill_STAT_NBRCTS(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen {
+		s.BASER, _ = strconv.ParseFloat(fields[1], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BASER_NCL, _ = strconv.ParseFloat(fields[2], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BASER_NCU, _ = strconv.ParseFloat(fields[3], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BASER_BCL, _ = strconv.ParseFloat(fields[4], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BASER_BCU, _ = strconv.ParseFloat(fields[5], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FMEAN, _ = strconv.ParseFloat(fields[6], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FMEAN_NCL, _ = strconv.ParseFloat(fields[7], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FMEAN_NCU, _ = strconv.ParseFloat(fields[8], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FMEAN_BCL, _ = strconv.ParseFloat(fields[9], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FMEAN_BCU, _ = strconv.ParseFloat(fields[10], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ACC, _ = strconv.ParseFloat(fields[11], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ACC_NCL, _ = strconv.ParseFloat(fields[12], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ACC_NCU, _ = strconv.ParseFloat(fields[13], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ACC_BCL, _ = strconv.ParseFloat(fields[14], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ACC_BCU, _ = strconv.ParseFloat(fields[15], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FBIAS, _ = strconv.ParseFloat(fields[16], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FBIAS_BCL, _ = strconv.ParseFloat(fields[17], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FBIAS_BCU, _ = strconv.ParseFloat(fields[18], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PODY, _ = strconv.ParseFloat(fields[19], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PODY_NCL, _ = strconv.ParseFloat(fields[20], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PODY_NCU, _ = strconv.ParseFloat(fields[21], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PODY_BCL, _ = strconv.ParseFloat(fields[22], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PODY_BCU, _ = strconv.ParseFloat(fields[23], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PODN, _ = strconv.ParseFloat(fields[24], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PODN_NCL, _ = strconv.ParseFloat(fields[25], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PODN_NCU, _ = strconv.ParseFloat(fields[26], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PODN_BCL, _ = strconv.ParseFloat(fields[27], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PODN_BCU, _ = strconv.ParseFloat(fields[28], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.POFD, _ = strconv.ParseFloat(fields[29], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.POFD_NCL, _ = strconv.ParseFloat(fields[30], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.POFD_NCU, _ = strconv.ParseFloat(fields[31], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.POFD_BCL, _ = strconv.ParseFloat(fields[32], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.POFD_BCU, _ = strconv.ParseFloat(fields[33], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FAR, _ = strconv.ParseFloat(fields[34], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FAR_NCL, _ = strconv.ParseFloat(fields[35], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FAR_NCU, _ = strconv.ParseFloat(fields[36], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FAR_BCL, _ = strconv.ParseFloat(fields[37], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FAR_BCU, _ = strconv.ParseFloat(fields[38], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CSI, _ = strconv.ParseFloat(fields[39], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CSI_NCL, _ = strconv.ParseFloat(fields[40], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CSI_NCU, _ = strconv.ParseFloat(fields[41], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CSI_BCL, _ = strconv.ParseFloat(fields[42], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CSI_BCU, _ = strconv.ParseFloat(fields[43], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.GSS, _ = strconv.ParseFloat(fields[44], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.GSS_BCL, _ = strconv.ParseFloat(fields[45], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.GSS_BCU, _ = strconv.ParseFloat(fields[46], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HK, _ = strconv.ParseFloat(fields[47], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HK_NCL, _ = strconv.ParseFloat(fields[48], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HK_NCU, _ = strconv.ParseFloat(fields[49], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HK_BCL, _ = strconv.ParseFloat(fields[50], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HK_BCU, _ = strconv.ParseFloat(fields[51], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HSS, _ = strconv.ParseFloat(fields[52], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HSS_BCL, _ = strconv.ParseFloat(fields[53], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HSS_BCU, _ = strconv.ParseFloat(fields[54], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ODDS, _ = strconv.ParseFloat(fields[55], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ODDS_NCL, _ = strconv.ParseFloat(fields[56], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ODDS_NCU, _ = strconv.ParseFloat(fields[57], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ODDS_BCL, _ = strconv.ParseFloat(fields[58], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ODDS_BCU, _ = strconv.ParseFloat(fields[59], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.LODDS, _ = strconv.ParseFloat(fields[60], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.LODDS_NCL, _ = strconv.ParseFloat(fields[61], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.LODDS_NCU, _ = strconv.ParseFloat(fields[62], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.LODDS_BCL, _ = strconv.ParseFloat(fields[63], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.LODDS_BCU, _ = strconv.ParseFloat(fields[64], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ORSS, _ = strconv.ParseFloat(fields[65], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ORSS_NCL, _ = strconv.ParseFloat(fields[66], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ORSS_NCU, _ = strconv.ParseFloat(fields[67], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ORSS_BCL, _ = strconv.ParseFloat(fields[68], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ORSS_BCU, _ = strconv.ParseFloat(fields[69], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.EDS, _ = strconv.ParseFloat(fields[70], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.EDS_NCL, _ = strconv.ParseFloat(fields[71], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.EDS_NCU, _ = strconv.ParseFloat(fields[72], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.EDS_BCL, _ = strconv.ParseFloat(fields[73], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.EDS_BCU, _ = strconv.ParseFloat(fields[74], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SEDS, _ = strconv.ParseFloat(fields[75], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SEDS_NCL, _ = strconv.ParseFloat(fields[76], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SEDS_NCU, _ = strconv.ParseFloat(fields[77], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SEDS_BCL, _ = strconv.ParseFloat(fields[78], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SEDS_BCU, _ = strconv.ParseFloat(fields[79], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.EDI, _ = strconv.ParseFloat(fields[80], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.EDI_NCL, _ = strconv.ParseFloat(fields[81], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.EDI_NCU, _ = strconv.ParseFloat(fields[82], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.EDI_BCL, _ = strconv.ParseFloat(fields[83], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.EDI_BCU, _ = strconv.ParseFloat(fields[84], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SEDI, _ = strconv.ParseFloat(fields[85], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SEDI_NCL, _ = strconv.ParseFloat(fields[86], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SEDI_NCU, _ = strconv.ParseFloat(fields[87], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SEDI_BCL, _ = strconv.ParseFloat(fields[88], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SEDI_BCU, _ = strconv.ParseFloat(fields[89], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BAGSS, _ = strconv.ParseFloat(fields[90], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BAGSS_BCL, _ = strconv.ParseFloat(fields[91], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BAGSS_BCU, _ = strconv.ParseFloat(fields[92], 64)
+	}
+}
+
+func (s *STAT_PJC) fill_STAT_PJC(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen { // the first field of the repeating fields is the TOTAL, the second field is the 1st dimenSion of the 1st sequence (there might be only one sequence)
+		var value interface{}
+		count, err := strconv.Atoi(fields[1])
+		if err != nil {
+			count = 0
+		}
+		keyPrefixes := []string{"THRESH_", "OY_TP_", "ON_TP_", "CALIBRATION_", "REFINEMENT", "LIKELIHOOD_", "BASER_"}
+		s.THRESH = make(map[string]interface{})
+		for group := 1; group <= count; group++ {
+			for index := 2; index <= len(keyPrefixes); index++ {
+				key := fmt.Sprintf("%s_%d", keyPrefixes[index-1], index)
+				if index > len(fields) { // sometimes the data line is truncated - we will set expected data to "NA"
+					value = "NA"
+				} else {
+					value, err = strconv.ParseFloat(fields[index], 64)
+					if err != nil { // sometimes there can be these NA values in the data, which will be left out of json
+						value = "NA"
+					}
+				}
+				s.THRESH[key] = value
+			}
+		}
+	}
+}
+
+func (s *STAT_SSVAR) fill_STAT_SSVAR(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen {
+		s.N_BIN, _ = strconv.Atoi(fields[1])
+	}
+	i++
+	if i <= dataLen {
+		s.BIN_I, _ = strconv.Atoi(fields[2])
+	}
+	i++
+	if i <= dataLen {
+		s.BIN_N, _ = strconv.Atoi(fields[3])
+	}
+	i++
+	if i <= dataLen {
+		s.VAR_MIN, _ = strconv.ParseFloat(fields[4], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.VAR_MAX, _ = strconv.ParseFloat(fields[5], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.VAR_MEAN, _ = strconv.ParseFloat(fields[6], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FBAR, _ = strconv.ParseFloat(fields[7], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OBAR, _ = strconv.ParseFloat(fields[8], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FOBAR, _ = strconv.ParseFloat(fields[9], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FFBAR, _ = strconv.ParseFloat(fields[10], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OOBAR, _ = strconv.ParseFloat(fields[11], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FBAR_NCL, _ = strconv.ParseFloat(fields[12], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FBAR_NCU, _ = strconv.ParseFloat(fields[13], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FSTDEV, _ = strconv.ParseFloat(fields[14], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FSTDEV_NCL, _ = strconv.ParseFloat(fields[15], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FSTDEV_NCU, _ = strconv.ParseFloat(fields[16], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OBAR_NCL, _ = strconv.ParseFloat(fields[17], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OBAR_NCU, _ = strconv.ParseFloat(fields[18], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OSTDEV, _ = strconv.ParseFloat(fields[19], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OSTDEV_NCL, _ = strconv.ParseFloat(fields[20], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OSTDEV_NCU, _ = strconv.ParseFloat(fields[21], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PR_CORR, _ = strconv.ParseFloat(fields[22], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PR_CORR_NCL, _ = strconv.ParseFloat(fields[23], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PR_CORR_NCU, _ = strconv.ParseFloat(fields[24], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ME, _ = strconv.ParseFloat(fields[25], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ME_NCL, _ = strconv.ParseFloat(fields[26], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ME_NCU, _ = strconv.ParseFloat(fields[27], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ESTDEV, _ = strconv.ParseFloat(fields[28], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ESTDEV_NCL, _ = strconv.ParseFloat(fields[29], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ESTDEV_NCU, _ = strconv.ParseFloat(fields[30], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.MBIAS, _ = strconv.ParseFloat(fields[31], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.MSE, _ = strconv.ParseFloat(fields[32], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BCMSE, _ = strconv.ParseFloat(fields[33], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.RMSE, _ = strconv.ParseFloat(fields[34], 64)
 	}
 }
 
@@ -6074,7 +6457,7 @@ func (s *STAT_CNT) fill_STAT_CNT(fields []string) {
 	}
 }
 
-func (s *STAT_ISC) fill_STAT_ISC(fields []string) {
+func (s *STAT_MCTC) fill_STAT_MCTC(fields []string) {
 	dataLen := len(fields) - 1
 	i := -1
 	i++
@@ -6082,52 +6465,130 @@ func (s *STAT_ISC) fill_STAT_ISC(fields []string) {
 		s.TOTAL, _ = strconv.Atoi(fields[0])
 	}
 	i++
-	if i <= dataLen {
-		s.TILE_DIM, _ = strconv.Atoi(fields[1])
+	if i <= dataLen { // these values seem to always be ints (or "NA")
+		var value interface{}
+		count, err := strconv.Atoi(fields[1])
+		if err != nil {
+			count = 0
+		}
+		s.CAT = make(map[string]interface{})
+		for i1 := 1; i1 <= count; i1++ {
+			for i2 := 1; i2 <= count; i2++ {
+				// generate the particular key for the map i.e. F1_O1, F1_O2, F1_O3, F1_O4, F2_O1, F2_O2, F2_O3, F2_O4, etc.
+				key := fmt.Sprintf("F%d_O%d", i1, i2)
+				index := (i1-1)*count + i2
+				if index >= len(fields) {
+					value = "NA"
+				} else {
+					value, err = strconv.Atoi(fields[index])
+				}
+				if err != nil {
+					value = "NA"
+				}
+				s.CAT[key] = value
+			}
+		}
 	}
 	i++
 	if i <= dataLen {
-		s.TILE_XLL, _ = strconv.Atoi(fields[2])
-	}
-	i++
-	if i <= dataLen {
-		s.TILE_YLL, _ = strconv.Atoi(fields[3])
-	}
-	i++
-	if i <= dataLen {
-		s.NSCALE, _ = strconv.Atoi(fields[4])
-	}
-	i++
-	if i <= dataLen {
-		s.ISCALE, _ = strconv.Atoi(fields[5])
-	}
-	i++
-	if i <= dataLen {
-		s.MSE, _ = strconv.ParseFloat(fields[6], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ISC, _ = strconv.ParseFloat(fields[7], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FENERGY2, _ = strconv.ParseFloat(fields[8], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OENERGY2, _ = strconv.ParseFloat(fields[9], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BASER, _ = strconv.ParseFloat(fields[10], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FBIAS, _ = strconv.ParseFloat(fields[11], 64)
+		s.EC_VALUE, _ = strconv.ParseFloat(fields[3], 64)
 	}
 }
 
-func (s *STAT_NBRCTS) fill_STAT_NBRCTS(fields []string) {
+func (s *STAT_PSTD) fill_STAT_PSTD(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen { // the first field of the repeating fields is the TOTAL, the second field is the 1st dimenSion of the 1st sequence (there might be only one sequence)
+		var value interface{}
+		count, err := strconv.Atoi(fields[1])
+		if err != nil {
+			count = 0
+		}
+		keyPrefixes := []string{"THRESH_"}
+		s.THRESH = make(map[string]interface{})
+		for group := 1; group <= count; group++ {
+			for index := 2; index <= len(keyPrefixes); index++ {
+				key := fmt.Sprintf("%s_%d", keyPrefixes[index-1], index)
+				if index > len(fields) { // sometimes the data line is truncated - we will set expected data to "NA"
+					value = "NA"
+				} else {
+					value, err = strconv.ParseFloat(fields[index], 64)
+					if err != nil { // sometimes there can be these NA values in the data, which will be left out of json
+						value = "NA"
+					}
+				}
+				s.THRESH[key] = value
+			}
+		}
+	}
+	i++
+	if i <= dataLen {
+		s.BASER_NCL, _ = strconv.ParseFloat(fields[3], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BASER_NCU, _ = strconv.ParseFloat(fields[4], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.RELIABILITY, _ = strconv.ParseFloat(fields[5], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.RESOLUTION, _ = strconv.ParseFloat(fields[6], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.UNCERTAINTY, _ = strconv.ParseFloat(fields[7], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ROC_AUC, _ = strconv.ParseFloat(fields[8], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BRIER, _ = strconv.ParseFloat(fields[9], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BRIER_NCL, _ = strconv.ParseFloat(fields[10], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BRIER_NCU, _ = strconv.ParseFloat(fields[11], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BRIERCL, _ = strconv.ParseFloat(fields[12], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BRIERCL_NCL, _ = strconv.ParseFloat(fields[13], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BRIERCL_NCU, _ = strconv.ParseFloat(fields[14], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BSS, _ = strconv.ParseFloat(fields[15], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BSS_SMPL, _ = strconv.ParseFloat(fields[16], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.THRESH_I, _ = strconv.Atoi(fields[17])
+	}
+}
+
+func (s *STAT_ECNT) fill_STAT_ECNT(fields []string) {
 	dataLen := len(fields) - 1
 	i := -1
 	i++
@@ -6136,371 +6597,302 @@ func (s *STAT_NBRCTS) fill_STAT_NBRCTS(fields []string) {
 	}
 	i++
 	if i <= dataLen {
-		s.BASER, _ = strconv.ParseFloat(fields[1], 64)
+		s.N_ENS, _ = strconv.Atoi(fields[1])
 	}
 	i++
 	if i <= dataLen {
-		s.BASER_NCL, _ = strconv.ParseFloat(fields[2], 64)
+		s.CRPS, _ = strconv.ParseFloat(fields[2], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.BASER_NCU, _ = strconv.ParseFloat(fields[3], 64)
+		s.CRPSS, _ = strconv.ParseFloat(fields[3], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.BASER_BCL, _ = strconv.ParseFloat(fields[4], 64)
+		s.IGN, _ = strconv.ParseFloat(fields[4], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.BASER_BCU, _ = strconv.ParseFloat(fields[5], 64)
+		s.ME, _ = strconv.ParseFloat(fields[5], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.FMEAN, _ = strconv.ParseFloat(fields[6], 64)
+		s.RMSE, _ = strconv.ParseFloat(fields[6], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.FMEAN_NCL, _ = strconv.ParseFloat(fields[7], 64)
+		s.SPREAD, _ = strconv.ParseFloat(fields[7], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.FMEAN_NCU, _ = strconv.ParseFloat(fields[8], 64)
+		s.ME_OERR, _ = strconv.ParseFloat(fields[8], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.FMEAN_BCL, _ = strconv.ParseFloat(fields[9], 64)
+		s.RMSE_OERR, _ = strconv.ParseFloat(fields[9], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.FMEAN_BCU, _ = strconv.ParseFloat(fields[10], 64)
+		s.SPREAD_OERR, _ = strconv.ParseFloat(fields[10], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.ACC, _ = strconv.ParseFloat(fields[11], 64)
+		s.SPREAD_PLUS_OERR, _ = strconv.ParseFloat(fields[11], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.ACC_NCL, _ = strconv.ParseFloat(fields[12], 64)
+		s.CRPSCL, _ = strconv.ParseFloat(fields[12], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.ACC_NCU, _ = strconv.ParseFloat(fields[13], 64)
+		s.CRPS_EMP, _ = strconv.ParseFloat(fields[13], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.ACC_BCL, _ = strconv.ParseFloat(fields[14], 64)
+		s.CRPSCL_EMP, _ = strconv.ParseFloat(fields[14], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.ACC_BCU, _ = strconv.ParseFloat(fields[15], 64)
+		s.CRPSS_EMP, _ = strconv.ParseFloat(fields[15], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.FBIAS, _ = strconv.ParseFloat(fields[16], 64)
+		s.CRPS_EMP_FAIR, _ = strconv.ParseFloat(fields[16], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.FBIAS_BCL, _ = strconv.ParseFloat(fields[17], 64)
+		s.SPREAD_MD, _ = strconv.ParseFloat(fields[17], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.FBIAS_BCU, _ = strconv.ParseFloat(fields[18], 64)
+		s.MAE, _ = strconv.ParseFloat(fields[18], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.PODY, _ = strconv.ParseFloat(fields[19], 64)
+		s.MAE_OERR, _ = strconv.ParseFloat(fields[19], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.PODY_NCL, _ = strconv.ParseFloat(fields[20], 64)
+		s.BIAS_RATIO, _ = strconv.ParseFloat(fields[20], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.PODY_NCU, _ = strconv.ParseFloat(fields[21], 64)
+		s.N_GE_OBS, _ = strconv.Atoi(fields[21])
 	}
 	i++
 	if i <= dataLen {
-		s.PODY_BCL, _ = strconv.ParseFloat(fields[22], 64)
+		s.ME_GE_OBS, _ = strconv.ParseFloat(fields[22], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.PODY_BCU, _ = strconv.ParseFloat(fields[23], 64)
+		s.N_LT_OBS, _ = strconv.Atoi(fields[23])
 	}
 	i++
 	if i <= dataLen {
-		s.PODN, _ = strconv.ParseFloat(fields[24], 64)
+		s.ME_LT_OBS, _ = strconv.ParseFloat(fields[24], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.PODN_NCL, _ = strconv.ParseFloat(fields[25], 64)
+		s.IGN_CONV_OERR, _ = strconv.ParseFloat(fields[25], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.PODN_NCU, _ = strconv.ParseFloat(fields[26], 64)
+		s.IGN_CORR_OERR, _ = strconv.ParseFloat(fields[26], 64)
 	}
+}
+
+func (s *MODE_CTS) fill_MODE_CTS(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
 	i++
 	if i <= dataLen {
-		s.PODN_BCL, _ = strconv.ParseFloat(fields[27], 64)
+		s.FIELD = fields[0]
 	}
 	i++
 	if i <= dataLen {
-		s.PODN_BCU, _ = strconv.ParseFloat(fields[28], 64)
+		s.TOTAL, _ = strconv.Atoi(fields[1])
 	}
 	i++
 	if i <= dataLen {
-		s.POFD, _ = strconv.ParseFloat(fields[29], 64)
+		s.FY_OY, _ = strconv.ParseFloat(fields[2], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.POFD_NCL, _ = strconv.ParseFloat(fields[30], 64)
+		s.FY_ON, _ = strconv.ParseFloat(fields[3], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.POFD_NCU, _ = strconv.ParseFloat(fields[31], 64)
+		s.FN_OY, _ = strconv.ParseFloat(fields[4], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.POFD_BCL, _ = strconv.ParseFloat(fields[32], 64)
+		s.FN_ON, _ = strconv.ParseFloat(fields[5], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.POFD_BCU, _ = strconv.ParseFloat(fields[33], 64)
+		s.BASER, _ = strconv.ParseFloat(fields[6], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.FAR, _ = strconv.ParseFloat(fields[34], 64)
+		s.FMEAN, _ = strconv.ParseFloat(fields[7], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.FAR_NCL, _ = strconv.ParseFloat(fields[35], 64)
+		s.ACC, _ = strconv.ParseFloat(fields[8], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.FAR_NCU, _ = strconv.ParseFloat(fields[36], 64)
+		s.FBIAS, _ = strconv.ParseFloat(fields[9], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.FAR_BCL, _ = strconv.ParseFloat(fields[37], 64)
+		s.PODY, _ = strconv.ParseFloat(fields[10], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.FAR_BCU, _ = strconv.ParseFloat(fields[38], 64)
+		s.PODN, _ = strconv.ParseFloat(fields[11], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.CSI, _ = strconv.ParseFloat(fields[39], 64)
+		s.POFD, _ = strconv.ParseFloat(fields[12], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.CSI_NCL, _ = strconv.ParseFloat(fields[40], 64)
+		s.FAR, _ = strconv.ParseFloat(fields[13], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.CSI_NCU, _ = strconv.ParseFloat(fields[41], 64)
+		s.CSI, _ = strconv.ParseFloat(fields[14], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.CSI_BCL, _ = strconv.ParseFloat(fields[42], 64)
+		s.GSS, _ = strconv.ParseFloat(fields[15], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.CSI_BCU, _ = strconv.ParseFloat(fields[43], 64)
+		s.HK, _ = strconv.ParseFloat(fields[16], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.GSS, _ = strconv.ParseFloat(fields[44], 64)
+		s.HSS, _ = strconv.ParseFloat(fields[17], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.GSS_BCL, _ = strconv.ParseFloat(fields[45], 64)
+		s.ODDS, _ = strconv.ParseFloat(fields[18], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.GSS_BCU, _ = strconv.ParseFloat(fields[46], 64)
+		s.LODDS, _ = strconv.ParseFloat(fields[19], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.HK, _ = strconv.ParseFloat(fields[47], 64)
+		s.ORSS, _ = strconv.ParseFloat(fields[20], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.HK_NCL, _ = strconv.ParseFloat(fields[48], 64)
+		s.EDS, _ = strconv.ParseFloat(fields[21], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.HK_NCU, _ = strconv.ParseFloat(fields[49], 64)
+		s.SEDS, _ = strconv.ParseFloat(fields[22], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.HK_BCL, _ = strconv.ParseFloat(fields[50], 64)
+		s.EDI, _ = strconv.ParseFloat(fields[23], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.HK_BCU, _ = strconv.ParseFloat(fields[51], 64)
+		s.SEDI, _ = strconv.ParseFloat(fields[24], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.HSS, _ = strconv.ParseFloat(fields[52], 64)
+		s.BAGSS, _ = strconv.ParseFloat(fields[25], 64)
 	}
+}
+
+func (s *MTD_3DPAIR) fill_MTD_3DPAIR(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
 	i++
 	if i <= dataLen {
-		s.HSS_BCL, _ = strconv.ParseFloat(fields[53], 64)
+		s.OBJECT_ID = fields[0]
 	}
 	i++
 	if i <= dataLen {
-		s.HSS_BCU, _ = strconv.ParseFloat(fields[54], 64)
+		s.OBJECT_CAT = fields[1]
 	}
 	i++
 	if i <= dataLen {
-		s.ODDS, _ = strconv.ParseFloat(fields[55], 64)
+		s.SPACE_CENTROID_DIST, _ = strconv.ParseFloat(fields[2], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.ODDS_NCL, _ = strconv.ParseFloat(fields[56], 64)
+		s.TIME_CENTROID_DELTA, _ = strconv.ParseFloat(fields[3], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.ODDS_NCU, _ = strconv.ParseFloat(fields[57], 64)
+		s.AXIS_DIFF, _ = strconv.ParseFloat(fields[4], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.ODDS_BCL, _ = strconv.ParseFloat(fields[58], 64)
+		s.SPEED_DELTA, _ = strconv.ParseFloat(fields[5], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.ODDS_BCU, _ = strconv.ParseFloat(fields[59], 64)
+		s.DIRECTION_DIFF, _ = strconv.ParseFloat(fields[6], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.LODDS, _ = strconv.ParseFloat(fields[60], 64)
+		s.VOLUME_RATIO, _ = strconv.ParseFloat(fields[7], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.LODDS_NCL, _ = strconv.ParseFloat(fields[61], 64)
+		s.START_TIME_DELTA, _ = strconv.Atoi(fields[8])
 	}
 	i++
 	if i <= dataLen {
-		s.LODDS_NCU, _ = strconv.ParseFloat(fields[62], 64)
+		s.END_TIME_DELTA, _ = strconv.Atoi(fields[9])
 	}
 	i++
 	if i <= dataLen {
-		s.LODDS_BCL, _ = strconv.ParseFloat(fields[63], 64)
+		s.INTERSECTION_VOLUME, _ = strconv.ParseFloat(fields[10], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.LODDS_BCU, _ = strconv.ParseFloat(fields[64], 64)
+		s.DURATION_DIFF, _ = strconv.ParseFloat(fields[11], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.ORSS, _ = strconv.ParseFloat(fields[65], 64)
+		s.INTEREST, _ = strconv.ParseFloat(fields[12], 64)
 	}
+}
+
+func (s *STAT_CTC) fill_STAT_CTC(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
 	i++
 	if i <= dataLen {
-		s.ORSS_NCL, _ = strconv.ParseFloat(fields[66], 64)
+		s.TOTAL, _ = strconv.Atoi(fields[0])
 	}
 	i++
 	if i <= dataLen {
-		s.ORSS_NCU, _ = strconv.ParseFloat(fields[67], 64)
+		s.FY_OY, _ = strconv.ParseFloat(fields[1], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.ORSS_BCL, _ = strconv.ParseFloat(fields[68], 64)
+		s.FY_ON, _ = strconv.ParseFloat(fields[2], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.ORSS_BCU, _ = strconv.ParseFloat(fields[69], 64)
+		s.FN_OY, _ = strconv.ParseFloat(fields[3], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.EDS, _ = strconv.ParseFloat(fields[70], 64)
+		s.FN_ON, _ = strconv.ParseFloat(fields[4], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.EDS_NCL, _ = strconv.ParseFloat(fields[71], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.EDS_NCU, _ = strconv.ParseFloat(fields[72], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.EDS_BCL, _ = strconv.ParseFloat(fields[73], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.EDS_BCU, _ = strconv.ParseFloat(fields[74], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SEDS, _ = strconv.ParseFloat(fields[75], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SEDS_NCL, _ = strconv.ParseFloat(fields[76], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SEDS_NCU, _ = strconv.ParseFloat(fields[77], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SEDS_BCL, _ = strconv.ParseFloat(fields[78], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SEDS_BCU, _ = strconv.ParseFloat(fields[79], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.EDI, _ = strconv.ParseFloat(fields[80], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.EDI_NCL, _ = strconv.ParseFloat(fields[81], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.EDI_NCU, _ = strconv.ParseFloat(fields[82], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.EDI_BCL, _ = strconv.ParseFloat(fields[83], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.EDI_BCU, _ = strconv.ParseFloat(fields[84], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SEDI, _ = strconv.ParseFloat(fields[85], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SEDI_NCL, _ = strconv.ParseFloat(fields[86], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SEDI_NCU, _ = strconv.ParseFloat(fields[87], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SEDI_BCL, _ = strconv.ParseFloat(fields[88], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SEDI_BCU, _ = strconv.ParseFloat(fields[89], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BAGSS, _ = strconv.ParseFloat(fields[90], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BAGSS_BCL, _ = strconv.ParseFloat(fields[91], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BAGSS_BCU, _ = strconv.ParseFloat(fields[92], 64)
+		s.EC_VALUE, _ = strconv.ParseFloat(fields[5], 64)
 	}
 }
 
@@ -6549,7 +6941,120 @@ func (s *STAT_GRAD) fill_STAT_GRAD(fields []string) {
 	}
 }
 
-func (s *STAT_PCT) fill_STAT_PCT(fields []string) {
+func (s *STAT_ORANK) fill_STAT_ORANK(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen {
+		s.INDEX, _ = strconv.Atoi(fields[1])
+	}
+	i++
+	if i <= dataLen {
+		s.OBS_SID = fields[2]
+	}
+	i++
+	if i <= dataLen {
+		s.OBS_LAT, _ = strconv.ParseFloat(fields[3], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OBS_LON, _ = strconv.ParseFloat(fields[4], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OBS_LVL, _ = strconv.ParseFloat(fields[5], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OBS_ELV, _ = strconv.ParseFloat(fields[6], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OBS, _ = strconv.ParseFloat(fields[7], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.PIT, _ = strconv.ParseFloat(fields[8], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.RANK, _ = strconv.Atoi(fields[9])
+	}
+	i++
+	if i <= dataLen {
+		s.N_ENS_VLD, _ = strconv.Atoi(fields[10])
+	}
+	i++
+	if i <= dataLen { // the first field of the repeating fields is the TOTAL, the second field is the 1st dimenSion of the 1st sequence (there might be only one sequence)
+		var value interface{}
+		count, err := strconv.Atoi(fields[11])
+		if err != nil {
+			count = 0
+		}
+		keyPrefixes := []string{"ENS_"}
+		s.ENS = make(map[string]interface{})
+		for group := 1; group <= count; group++ {
+			for index := 12; index <= len(keyPrefixes); index++ {
+				key := fmt.Sprintf("%s_%d", keyPrefixes[index-1], index)
+				if index > len(fields) { // sometimes the data line is truncated - we will set expected data to "NA"
+					value = "NA"
+				} else {
+					value, err = strconv.Atoi(fields[index])
+					if err != nil { // sometimes there can be these NA values in the data, which will be left out of json
+						value = "NA"
+					}
+				}
+				s.ENS[key] = value
+			}
+		}
+	}
+	i++
+	if i <= dataLen {
+		s.OBS_QC = fields[13]
+	}
+	i++
+	if i <= dataLen {
+		s.ENS_MEAN, _ = strconv.Atoi(fields[14])
+	}
+	i++
+	if i <= dataLen {
+		s.OBS_CLIMO_MEAN, _ = strconv.ParseFloat(fields[15], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SPREAD, _ = strconv.ParseFloat(fields[16], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ENS_MEAN_OERR, _ = strconv.Atoi(fields[17])
+	}
+	i++
+	if i <= dataLen {
+		s.SPREAD_OERR, _ = strconv.ParseFloat(fields[18], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.SPREAD_PLUS_OERR, _ = strconv.ParseFloat(fields[19], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OBS_CLIMO_STDEV, _ = strconv.ParseFloat(fields[20], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FCST_CLIMO_MEAN, _ = strconv.ParseFloat(fields[21], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FCST_CLIMO_STDEV, _ = strconv.ParseFloat(fields[22], 64)
+	}
+}
+
+func (s *STAT_RHIST) fill_STAT_RHIST(fields []string) {
 	dataLen := len(fields) - 1
 	i := -1
 	i++
@@ -6563,7 +7068,512 @@ func (s *STAT_PCT) fill_STAT_PCT(fields []string) {
 		if err != nil {
 			count = 0
 		}
-		keyPrefixes := []string{"THRESH_", "OY_", "ON_"}
+		keyPrefixes := []string{"RANK_"}
+		s.RANK = make(map[string]interface{})
+		for group := 1; group <= count; group++ {
+			for index := 2; index <= len(keyPrefixes); index++ {
+				key := fmt.Sprintf("%s_%d", keyPrefixes[index-1], index)
+				if index > len(fields) { // sometimes the data line is truncated - we will set expected data to "NA"
+					value = "NA"
+				} else {
+					value, err = strconv.Atoi(fields[index])
+					if err != nil { // sometimes there can be these NA values in the data, which will be left out of json
+						value = "NA"
+					}
+				}
+				s.RANK[key] = value
+			}
+		}
+	}
+}
+
+func (s *STAT_SL1L2) fill_STAT_SL1L2(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen {
+		s.FBAR, _ = strconv.ParseFloat(fields[1], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OBAR, _ = strconv.ParseFloat(fields[2], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FOBAR, _ = strconv.ParseFloat(fields[3], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FFBAR, _ = strconv.ParseFloat(fields[4], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OOBAR, _ = strconv.ParseFloat(fields[5], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.MAE, _ = strconv.ParseFloat(fields[6], 64)
+	}
+}
+
+func (s *STAT_VAL1L2) fill_STAT_VAL1L2(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen {
+		s.UFABAR, _ = strconv.ParseFloat(fields[1], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.VFABAR, _ = strconv.ParseFloat(fields[2], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.UOABAR, _ = strconv.ParseFloat(fields[3], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.VOABAR, _ = strconv.ParseFloat(fields[4], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.UVFOABAR, _ = strconv.ParseFloat(fields[5], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.UVFFABAR, _ = strconv.ParseFloat(fields[6], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.UVOOABAR, _ = strconv.ParseFloat(fields[7], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.FA_SPEED_BAR, _ = strconv.ParseFloat(fields[8], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.OA_SPEED_BAR, _ = strconv.ParseFloat(fields[9], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.TOTAL_DIR, _ = strconv.ParseFloat(fields[10], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.DIRA_ME, _ = strconv.ParseFloat(fields[11], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.DIRA_MAE, _ = strconv.ParseFloat(fields[12], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.DIRA_MSE, _ = strconv.ParseFloat(fields[13], 64)
+	}
+}
+
+func (s *TCST_TCMPR) fill_TCST_TCMPR(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen {
+		s.INDEX, _ = strconv.Atoi(fields[1])
+	}
+	i++
+	if i <= dataLen {
+		s.LEVEL = fields[2]
+	}
+	i++
+	if i <= dataLen {
+		s.WATCH_WARN = fields[3]
+	}
+	i++
+	if i <= dataLen {
+		s.INITIALS = fields[4]
+	}
+	i++
+	if i <= dataLen {
+		s.ALAT, _ = strconv.ParseFloat(fields[5], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ALON, _ = strconv.ParseFloat(fields[6], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BLAT, _ = strconv.ParseFloat(fields[7], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BLON, _ = strconv.ParseFloat(fields[8], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.TK_ERR, _ = strconv.ParseFloat(fields[9], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.X_ERR, _ = strconv.ParseFloat(fields[10], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.Y_ERR, _ = strconv.ParseFloat(fields[11], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ALTK_ERR, _ = strconv.ParseFloat(fields[12], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.CRTK_ERR, _ = strconv.ParseFloat(fields[13], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ADLAND, _ = strconv.ParseFloat(fields[14], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BDLAND, _ = strconv.ParseFloat(fields[15], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.AMSLP, _ = strconv.ParseFloat(fields[16], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BMSLP, _ = strconv.ParseFloat(fields[17], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.AMAX_WIND, _ = strconv.ParseFloat(fields[18], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BMAX_WIND, _ = strconv.ParseFloat(fields[19], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.AAL_WIND_34, _ = strconv.ParseFloat(fields[20], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BAL_WIND_34, _ = strconv.ParseFloat(fields[21], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ANE_WIND_34, _ = strconv.ParseFloat(fields[22], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BNE_WIND_34, _ = strconv.ParseFloat(fields[23], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ASE_WIND_34, _ = strconv.ParseFloat(fields[24], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BSE_WIND_34, _ = strconv.ParseFloat(fields[25], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ASW_WIND_34, _ = strconv.ParseFloat(fields[26], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BSW_WIND_34, _ = strconv.ParseFloat(fields[27], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ANW_WIND_34, _ = strconv.ParseFloat(fields[28], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BNW_WIND_34, _ = strconv.ParseFloat(fields[29], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.AAL_WIND_50, _ = strconv.ParseFloat(fields[30], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BAL_WIND_50, _ = strconv.ParseFloat(fields[31], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ANE_WIND_50, _ = strconv.ParseFloat(fields[32], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BNE_WIND_50, _ = strconv.ParseFloat(fields[33], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ASE_WIND_50, _ = strconv.ParseFloat(fields[34], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BSE_WIND_50, _ = strconv.ParseFloat(fields[35], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ASW_WIND_50, _ = strconv.ParseFloat(fields[36], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BSW_WIND_50, _ = strconv.ParseFloat(fields[37], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ANW_WIND_50, _ = strconv.ParseFloat(fields[38], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BNW_WIND_50, _ = strconv.ParseFloat(fields[39], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.AAL_WIND_64, _ = strconv.ParseFloat(fields[40], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BAL_WIND_64, _ = strconv.ParseFloat(fields[41], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ANE_WIND_64, _ = strconv.ParseFloat(fields[42], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BNE_WIND_64, _ = strconv.ParseFloat(fields[43], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ASE_WIND_64, _ = strconv.ParseFloat(fields[44], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BSE_WIND_64, _ = strconv.ParseFloat(fields[45], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ASW_WIND_64, _ = strconv.ParseFloat(fields[46], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BSW_WIND_64, _ = strconv.ParseFloat(fields[47], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ANW_WIND_64, _ = strconv.ParseFloat(fields[48], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BNW_WIND_64, _ = strconv.ParseFloat(fields[49], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ARADP = fields[50]
+	}
+	i++
+	if i <= dataLen {
+		s.BRADP, _ = strconv.ParseFloat(fields[51], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ARRP, _ = strconv.Atoi(fields[52])
+	}
+	i++
+	if i <= dataLen {
+		s.BRRP, _ = strconv.ParseFloat(fields[53], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.AMRD, _ = strconv.Atoi(fields[54])
+	}
+	i++
+	if i <= dataLen {
+		s.BMRD, _ = strconv.ParseFloat(fields[55], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.AGUSTS, _ = strconv.Atoi(fields[56])
+	}
+	i++
+	if i <= dataLen {
+		s.BGUSTS, _ = strconv.ParseFloat(fields[57], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.AEYE, _ = strconv.Atoi(fields[58])
+	}
+	i++
+	if i <= dataLen {
+		s.BEYE, _ = strconv.ParseFloat(fields[59], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ADIR, _ = strconv.Atoi(fields[60])
+	}
+	i++
+	if i <= dataLen {
+		s.BDIR, _ = strconv.ParseFloat(fields[61], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ASPEED, _ = strconv.Atoi(fields[62])
+	}
+	i++
+	if i <= dataLen {
+		s.BSPEED, _ = strconv.ParseFloat(fields[63], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ADEPTH, _ = strconv.Atoi(fields[64])
+	}
+	i++
+	if i <= dataLen {
+		s.BDEPTH, _ = strconv.ParseFloat(fields[65], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.NUM_MEMBERS, _ = strconv.ParseFloat(fields[66], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.TRACK_SPREAD, _ = strconv.ParseFloat(fields[67], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.TRACK_STDEV, _ = strconv.ParseFloat(fields[68], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.MSLP_STDEV, _ = strconv.ParseFloat(fields[69], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.MAX_WIND_STDEV, _ = strconv.ParseFloat(fields[70], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INIT, _ = strconv.Atoi(fields[71])
+	}
+}
+
+func (s *STAT_MCTS) fill_STAT_MCTS(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen {
+		s.N_CAT, _ = strconv.Atoi(fields[1])
+	}
+	i++
+	if i <= dataLen {
+		s.ACC, _ = strconv.ParseFloat(fields[2], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ACC_NCL, _ = strconv.ParseFloat(fields[3], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ACC_NCU, _ = strconv.ParseFloat(fields[4], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ACC_BCL, _ = strconv.ParseFloat(fields[5], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ACC_BCU, _ = strconv.ParseFloat(fields[6], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HK, _ = strconv.ParseFloat(fields[7], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HK_BCL, _ = strconv.ParseFloat(fields[8], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HK_BCU, _ = strconv.ParseFloat(fields[9], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HSS, _ = strconv.ParseFloat(fields[10], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HSS_BCL, _ = strconv.ParseFloat(fields[11], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HSS_BCU, _ = strconv.ParseFloat(fields[12], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.GER, _ = strconv.ParseFloat(fields[13], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.GER_BCL, _ = strconv.ParseFloat(fields[14], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.GER_BCU, _ = strconv.ParseFloat(fields[15], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HSS_EC, _ = strconv.ParseFloat(fields[16], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HSS_EC_BCL, _ = strconv.ParseFloat(fields[17], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.HSS_EC_BCU, _ = strconv.ParseFloat(fields[18], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.EC_VALUE, _ = strconv.ParseFloat(fields[19], 64)
+	}
+}
+
+func (s *STAT_PRC) fill_STAT_PRC(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.TOTAL, _ = strconv.Atoi(fields[0])
+	}
+	i++
+	if i <= dataLen { // the first field of the repeating fields is the TOTAL, the second field is the 1st dimenSion of the 1st sequence (there might be only one sequence)
+		var value interface{}
+		count, err := strconv.Atoi(fields[1])
+		if err != nil {
+			count = 0
+		}
+		keyPrefixes := []string{"THRESH_", "PODY_", "POFD_"}
 		s.THRESH = make(map[string]interface{})
 		for group := 1; group <= count; group++ {
 			for index := 2; index <= len(keyPrefixes); index++ {
@@ -6623,40 +7633,92 @@ func (s *STAT_RPS) fill_STAT_RPS(fields []string) {
 	}
 }
 
-func (s *STAT_SAL1L2) fill_STAT_SAL1L2(fields []string) {
+func (s *MTD_3DSINGLE) fill_MTD_3DSINGLE(fields []string) {
 	dataLen := len(fields) - 1
 	i := -1
 	i++
 	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
+		s.OBJECT_ID = fields[0]
 	}
 	i++
 	if i <= dataLen {
-		s.FABAR, _ = strconv.ParseFloat(fields[1], 64)
+		s.OBJECT_CAT = fields[1]
 	}
 	i++
 	if i <= dataLen {
-		s.OABAR, _ = strconv.ParseFloat(fields[2], 64)
+		s.CENTROID_X, _ = strconv.ParseFloat(fields[2], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.FOABAR, _ = strconv.ParseFloat(fields[3], 64)
+		s.CENTROID_Y, _ = strconv.ParseFloat(fields[3], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.FFABAR, _ = strconv.ParseFloat(fields[4], 64)
+		s.CENTROID_T, _ = strconv.ParseFloat(fields[4], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.OOABAR, _ = strconv.ParseFloat(fields[5], 64)
+		s.CENTROID_LAT, _ = strconv.ParseFloat(fields[5], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.MAE, _ = strconv.ParseFloat(fields[6], 64)
+		s.CENTROID_LON, _ = strconv.ParseFloat(fields[6], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.X_DOT, _ = strconv.ParseFloat(fields[7], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.Y_DOT, _ = strconv.ParseFloat(fields[8], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.AXIS_ANG, _ = strconv.ParseFloat(fields[9], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.VOLUME, _ = strconv.Atoi(fields[10])
+	}
+	i++
+	if i <= dataLen {
+		s.START_TIME, _ = strconv.Atoi(fields[11])
+	}
+	i++
+	if i <= dataLen {
+		s.END_TIME, _ = strconv.Atoi(fields[12])
+	}
+	i++
+	if i <= dataLen {
+		s.CDIST_TRAVELLED, _ = strconv.ParseFloat(fields[13], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTENSITY_10, _ = strconv.ParseFloat(fields[14], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTENSITY_25, _ = strconv.ParseFloat(fields[15], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTENSITY_50, _ = strconv.ParseFloat(fields[16], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTENSITY_75, _ = strconv.ParseFloat(fields[17], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTENSITY_90, _ = strconv.ParseFloat(fields[18], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INTENSITY_USER, _ = strconv.ParseFloat(fields[19], 64)
 	}
 }
 
-func (s *STAT_SL1L2) fill_STAT_SL1L2(fields []string) {
+func (s *TCST_TCDIAG) fill_TCST_TCDIAG(fields []string) {
 	dataLen := len(fields) - 1
 	i := -1
 	i++
@@ -6665,27 +7727,157 @@ func (s *STAT_SL1L2) fill_STAT_SL1L2(fields []string) {
 	}
 	i++
 	if i <= dataLen {
-		s.FBAR, _ = strconv.ParseFloat(fields[1], 64)
+		s.INDEX, _ = strconv.Atoi(fields[1])
 	}
 	i++
 	if i <= dataLen {
-		s.OBAR, _ = strconv.ParseFloat(fields[2], 64)
+		s.DIAG_SOURCE, _ = strconv.ParseFloat(fields[2], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.FOBAR, _ = strconv.ParseFloat(fields[3], 64)
+		s.TRACK_SOURCE = fields[3]
 	}
 	i++
 	if i <= dataLen {
-		s.FFBAR, _ = strconv.ParseFloat(fields[4], 64)
+		s.FIELD_SOURCE = fields[4]
+	}
+	i++
+	if i <= dataLen { // the first field of the repeating fields is the TOTAL, the second field is the 1st dimenSion of the 1st sequence (there might be only one sequence)
+		var value interface{}
+		count, err := strconv.Atoi(fields[5])
+		if err != nil {
+			count = 0
+		}
+		keyPrefixes := []string{"DIAG_", "VALUE_"}
+		s.DIAG = make(map[string]interface{})
+		for group := 1; group <= count; group++ {
+			for index := 6; index <= len(keyPrefixes); index++ {
+				key := fmt.Sprintf("%s_%d", keyPrefixes[index-1], index)
+				if index > len(fields) { // sometimes the data line is truncated - we will set expected data to "NA"
+					value = "NA"
+				} else {
+					value = fields[index]
+				}
+				s.DIAG[key] = value
+			}
+		}
 	}
 	i++
 	if i <= dataLen {
-		s.OOBAR, _ = strconv.ParseFloat(fields[5], 64)
+		s.INIT, _ = strconv.Atoi(fields[8])
+	}
+}
+
+func (s *TCST_PROBRIRW) fill_TCST_PROBRIRW(fields []string) {
+	dataLen := len(fields) - 1
+	i := -1
+	i++
+	if i <= dataLen {
+		s.ALAT, _ = strconv.ParseFloat(fields[0], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.MAE, _ = strconv.ParseFloat(fields[6], 64)
+		s.ALON, _ = strconv.ParseFloat(fields[1], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BLAT, _ = strconv.ParseFloat(fields[2], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BLON, _ = strconv.ParseFloat(fields[3], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.INITIALS = fields[4]
+	}
+	i++
+	if i <= dataLen {
+		s.TK_ERR, _ = strconv.ParseFloat(fields[5], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.X_ERR, _ = strconv.ParseFloat(fields[6], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.Y_ERR, _ = strconv.ParseFloat(fields[7], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.ADLAND, _ = strconv.ParseFloat(fields[8], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BDLAND, _ = strconv.ParseFloat(fields[9], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.RIRW_BEG, _ = strconv.Atoi(fields[10])
+	}
+	i++
+	if i <= dataLen {
+		s.RIRW_END, _ = strconv.Atoi(fields[11])
+	}
+	i++
+	if i <= dataLen {
+		s.RIRW_WINDOW, _ = strconv.Atoi(fields[12])
+	}
+	i++
+	if i <= dataLen {
+		s.AWIND_END, _ = strconv.ParseFloat(fields[13], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BWIND_BEG, _ = strconv.ParseFloat(fields[14], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BWIND_END, _ = strconv.ParseFloat(fields[15], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BDELTA, _ = strconv.ParseFloat(fields[16], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BDELTA_MAX, _ = strconv.ParseFloat(fields[17], 64)
+	}
+	i++
+	if i <= dataLen {
+		s.BLEVEL_BEG = fields[18]
+	}
+	i++
+	if i <= dataLen {
+		s.BLEVEL_END = fields[19]
+	}
+	i++
+	if i <= dataLen { // the first field of the repeating fields is the TOTAL, the second field is the 1st dimenSion of the 1st sequence (there might be only one sequence)
+		var value interface{}
+		count, err := strconv.Atoi(fields[20])
+		if err != nil {
+			count = 0
+		}
+		keyPrefixes := []string{"THRESH_", "PROB_"}
+		s.THRESH = make(map[string]interface{})
+		for group := 1; group <= count; group++ {
+			for index := 21; index <= len(keyPrefixes); index++ {
+				key := fmt.Sprintf("%s_%d", keyPrefixes[index-1], index)
+				if index > len(fields) { // sometimes the data line is truncated - we will set expected data to "NA"
+					value = "NA"
+				} else {
+					value, err = strconv.Atoi(fields[index])
+					if err != nil { // sometimes there can be these NA values in the data, which will be left out of json
+						value = "NA"
+					}
+				}
+				s.THRESH[key] = value
+			}
+		}
+	}
+	i++
+	if i <= dataLen {
+		s.INIT, _ = strconv.Atoi(fields[23])
 	}
 }
 
@@ -7082,167 +8274,7 @@ func (s *STAT_CTS) fill_STAT_CTS(fields []string) {
 	}
 }
 
-func (s *STAT_MCTC) fill_STAT_MCTC(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen { // these values seem to always be ints (or "NA")
-		var value interface{}
-		count, err := strconv.Atoi(fields[1])
-		if err != nil {
-			count = 0
-		}
-		s.CAT = make(map[string]interface{})
-		for i1 := 1; i1 <= count; i1++ {
-			for i2 := 1; i2 <= count; i2++ {
-				// generate the particular key for the map i.e. F1_O1, F1_O2, F1_O3, F1_O4, F2_O1, F2_O2, F2_O3, F2_O4, etc.
-				key := fmt.Sprintf("F%d_O%d", i1, i2)
-				index := (i1-1)*count + i2
-				if index >= len(fields) {
-					value = "NA"
-				} else {
-					value, err = strconv.Atoi(fields[index])
-				}
-				if err != nil {
-					value = "NA"
-				}
-				s.CAT[key] = value
-			}
-		}
-	}
-	i++
-	if i <= dataLen {
-		s.EC_VALUE, _ = strconv.ParseFloat(fields[3], 64)
-	}
-}
-
-func (s *STAT_SEEPS_MPR) fill_STAT_SEEPS_MPR(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.OBS_SID = fields[0]
-	}
-	i++
-	if i <= dataLen {
-		s.OBS_LAT, _ = strconv.ParseFloat(fields[1], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OBS_LON, _ = strconv.ParseFloat(fields[2], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FCST, _ = strconv.ParseFloat(fields[3], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OBS, _ = strconv.ParseFloat(fields[4], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OBS_QC = fields[5]
-	}
-	i++
-	if i <= dataLen {
-		s.FCST_CAT, _ = strconv.Atoi(fields[6])
-	}
-	i++
-	if i <= dataLen {
-		s.OBS_CAT, _ = strconv.Atoi(fields[7])
-	}
-	i++
-	if i <= dataLen {
-		s.P1, _ = strconv.ParseFloat(fields[8], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.P2, _ = strconv.ParseFloat(fields[9], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.T1, _ = strconv.ParseFloat(fields[10], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.T2, _ = strconv.ParseFloat(fields[11], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SEEPS, _ = strconv.ParseFloat(fields[12], 64)
-	}
-}
-
-func (s *MTD_2DSINGLE) fill_MTD_2DSINGLE(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.OBJECT_ID = fields[0]
-	}
-	i++
-	if i <= dataLen {
-		s.OBJECT_CAT = fields[1]
-	}
-	i++
-	if i <= dataLen {
-		s.TIME_INDEX, _ = strconv.Atoi(fields[2])
-	}
-	i++
-	if i <= dataLen {
-		s.AREA, _ = strconv.Atoi(fields[3])
-	}
-	i++
-	if i <= dataLen {
-		s.CENTROID_X, _ = strconv.ParseFloat(fields[4], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CENTROID_Y, _ = strconv.ParseFloat(fields[5], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CENTROID_LAT, _ = strconv.ParseFloat(fields[6], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CENTROID_LON, _ = strconv.ParseFloat(fields[7], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AXIS_ANG, _ = strconv.ParseFloat(fields[8], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTENSITY_10, _ = strconv.ParseFloat(fields[9], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTENSITY_25, _ = strconv.ParseFloat(fields[10], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTENSITY_50, _ = strconv.ParseFloat(fields[11], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTENSITY_75, _ = strconv.ParseFloat(fields[12], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTENSITY_90, _ = strconv.ParseFloat(fields[13], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTENSITY_USER, _ = strconv.ParseFloat(fields[14], 64)
-	}
-}
-
-func (s *STAT_ECNT) fill_STAT_ECNT(fields []string) {
+func (s *STAT_NBRCNT) fill_STAT_NBRCNT(fields []string) {
 	dataLen := len(fields) - 1
 	i := -1
 	i++
@@ -7251,554 +8283,75 @@ func (s *STAT_ECNT) fill_STAT_ECNT(fields []string) {
 	}
 	i++
 	if i <= dataLen {
-		s.N_ENS, _ = strconv.Atoi(fields[1])
+		s.FBS, _ = strconv.ParseFloat(fields[1], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.CRPS, _ = strconv.ParseFloat(fields[2], 64)
+		s.FBS_BCL, _ = strconv.ParseFloat(fields[2], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.CRPSS, _ = strconv.ParseFloat(fields[3], 64)
+		s.FBS_BCU, _ = strconv.ParseFloat(fields[3], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.IGN, _ = strconv.ParseFloat(fields[4], 64)
+		s.FSS, _ = strconv.ParseFloat(fields[4], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.ME, _ = strconv.ParseFloat(fields[5], 64)
+		s.FSS_BCL, _ = strconv.ParseFloat(fields[5], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.RMSE, _ = strconv.ParseFloat(fields[6], 64)
+		s.FSS_BCU, _ = strconv.ParseFloat(fields[6], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.SPREAD, _ = strconv.ParseFloat(fields[7], 64)
+		s.AFSS, _ = strconv.ParseFloat(fields[7], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.ME_OERR, _ = strconv.ParseFloat(fields[8], 64)
+		s.AFSS_BCL, _ = strconv.ParseFloat(fields[8], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.RMSE_OERR, _ = strconv.ParseFloat(fields[9], 64)
+		s.AFSS_BCU, _ = strconv.ParseFloat(fields[9], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.SPREAD_OERR, _ = strconv.ParseFloat(fields[10], 64)
+		s.UFSS, _ = strconv.ParseFloat(fields[10], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.SPREAD_PLUS_OERR, _ = strconv.ParseFloat(fields[11], 64)
+		s.UFSS_BCL, _ = strconv.ParseFloat(fields[11], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.CRPSCL, _ = strconv.ParseFloat(fields[12], 64)
+		s.UFSS_BCU, _ = strconv.ParseFloat(fields[12], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.CRPS_EMP, _ = strconv.ParseFloat(fields[13], 64)
+		s.F_RATE, _ = strconv.ParseFloat(fields[13], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.CRPSCL_EMP, _ = strconv.ParseFloat(fields[14], 64)
+		s.F_RATE_BCL, _ = strconv.ParseFloat(fields[14], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.CRPSS_EMP, _ = strconv.ParseFloat(fields[15], 64)
+		s.F_RATE_BCU, _ = strconv.ParseFloat(fields[15], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.CRPS_EMP_FAIR, _ = strconv.ParseFloat(fields[16], 64)
+		s.O_RATE, _ = strconv.ParseFloat(fields[16], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.SPREAD_MD, _ = strconv.ParseFloat(fields[17], 64)
+		s.O_RATE_BCL, _ = strconv.ParseFloat(fields[17], 64)
 	}
 	i++
 	if i <= dataLen {
-		s.MAE, _ = strconv.ParseFloat(fields[18], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.MAE_OERR, _ = strconv.ParseFloat(fields[19], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BIAS_RATIO, _ = strconv.ParseFloat(fields[20], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.N_GE_OBS, _ = strconv.Atoi(fields[21])
-	}
-	i++
-	if i <= dataLen {
-		s.ME_GE_OBS, _ = strconv.ParseFloat(fields[22], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.N_LT_OBS, _ = strconv.Atoi(fields[23])
-	}
-	i++
-	if i <= dataLen {
-		s.ME_LT_OBS, _ = strconv.ParseFloat(fields[24], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.IGN_CONV_OERR, _ = strconv.ParseFloat(fields[25], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.IGN_CORR_OERR, _ = strconv.ParseFloat(fields[26], 64)
-	}
-}
-
-func (s *STAT_VAL1L2) fill_STAT_VAL1L2(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen {
-		s.UFABAR, _ = strconv.ParseFloat(fields[1], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.VFABAR, _ = strconv.ParseFloat(fields[2], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.UOABAR, _ = strconv.ParseFloat(fields[3], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.VOABAR, _ = strconv.ParseFloat(fields[4], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.UVFOABAR, _ = strconv.ParseFloat(fields[5], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.UVFFABAR, _ = strconv.ParseFloat(fields[6], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.UVOOABAR, _ = strconv.ParseFloat(fields[7], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FA_SPEED_BAR, _ = strconv.ParseFloat(fields[8], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OA_SPEED_BAR, _ = strconv.ParseFloat(fields[9], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.TOTAL_DIR, _ = strconv.ParseFloat(fields[10], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.DIRA_ME, _ = strconv.ParseFloat(fields[11], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.DIRA_MAE, _ = strconv.ParseFloat(fields[12], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.DIRA_MSE, _ = strconv.ParseFloat(fields[13], 64)
-	}
-}
-
-func (s *STAT_SSIDX) fill_STAT_SSIDX(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.FCST_MODEL = fields[0]
-	}
-	i++
-	if i <= dataLen {
-		s.REF_MODEL = fields[1]
-	}
-	i++
-	if i <= dataLen {
-		s.N_INIT, _ = strconv.Atoi(fields[2])
-	}
-	i++
-	if i <= dataLen {
-		s.N_TERM, _ = strconv.Atoi(fields[3])
-	}
-	i++
-	if i <= dataLen {
-		s.N_VLD, _ = strconv.Atoi(fields[4])
-	}
-	i++
-	if i <= dataLen {
-		s.SS_INDEX, _ = strconv.ParseFloat(fields[5], 64)
-	}
-}
-
-func (s *TCST_PROBRIRW) fill_TCST_PROBRIRW(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.ALAT, _ = strconv.ParseFloat(fields[0], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ALON, _ = strconv.ParseFloat(fields[1], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BLAT, _ = strconv.ParseFloat(fields[2], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BLON, _ = strconv.ParseFloat(fields[3], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INITIALS = fields[4]
-	}
-	i++
-	if i <= dataLen {
-		s.TK_ERR, _ = strconv.ParseFloat(fields[5], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.X_ERR, _ = strconv.ParseFloat(fields[6], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.Y_ERR, _ = strconv.ParseFloat(fields[7], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ADLAND, _ = strconv.ParseFloat(fields[8], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BDLAND, _ = strconv.ParseFloat(fields[9], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.RIRW_BEG, _ = strconv.Atoi(fields[10])
-	}
-	i++
-	if i <= dataLen {
-		s.RIRW_END, _ = strconv.Atoi(fields[11])
-	}
-	i++
-	if i <= dataLen {
-		s.RIRW_WINDOW, _ = strconv.Atoi(fields[12])
-	}
-	i++
-	if i <= dataLen {
-		s.AWIND_END, _ = strconv.ParseFloat(fields[13], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BWIND_BEG, _ = strconv.ParseFloat(fields[14], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BWIND_END, _ = strconv.ParseFloat(fields[15], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BDELTA, _ = strconv.ParseFloat(fields[16], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BDELTA_MAX, _ = strconv.ParseFloat(fields[17], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BLEVEL_BEG = fields[18]
-	}
-	i++
-	if i <= dataLen {
-		s.BLEVEL_END = fields[19]
-	}
-	i++
-	if i <= dataLen { // the first field of the repeating fields is the TOTAL, the second field is the 1st dimenSion of the 1st sequence (there might be only one sequence)
-		var value interface{}
-		count, err := strconv.Atoi(fields[20])
-		if err != nil {
-			count = 0
-		}
-		keyPrefixes := []string{"THRESH_", "PROB_"}
-		s.THRESH = make(map[string]interface{})
-		for group := 1; group <= count; group++ {
-			for index := 21; index <= len(keyPrefixes); index++ {
-				key := fmt.Sprintf("%s_%d", keyPrefixes[index-1], index)
-				if index > len(fields) { // sometimes the data line is truncated - we will set expected data to "NA"
-					value = "NA"
-				} else {
-					value, err = strconv.Atoi(fields[index])
-					if err != nil { // sometimes there can be these NA values in the data, which will be left out of json
-						value = "NA"
-					}
-				}
-				s.THRESH[key] = value
-			}
-		}
-	}
-	i++
-	if i <= dataLen {
-		s.INIT, _ = strconv.Atoi(fields[23])
-	}
-}
-
-func (s *STAT_MCTS) fill_STAT_MCTS(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen {
-		s.N_CAT, _ = strconv.Atoi(fields[1])
-	}
-	i++
-	if i <= dataLen {
-		s.ACC, _ = strconv.ParseFloat(fields[2], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ACC_NCL, _ = strconv.ParseFloat(fields[3], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ACC_NCU, _ = strconv.ParseFloat(fields[4], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ACC_BCL, _ = strconv.ParseFloat(fields[5], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ACC_BCU, _ = strconv.ParseFloat(fields[6], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HK, _ = strconv.ParseFloat(fields[7], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HK_BCL, _ = strconv.ParseFloat(fields[8], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HK_BCU, _ = strconv.ParseFloat(fields[9], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HSS, _ = strconv.ParseFloat(fields[10], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HSS_BCL, _ = strconv.ParseFloat(fields[11], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HSS_BCU, _ = strconv.ParseFloat(fields[12], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.GER, _ = strconv.ParseFloat(fields[13], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.GER_BCL, _ = strconv.ParseFloat(fields[14], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.GER_BCU, _ = strconv.ParseFloat(fields[15], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HSS_EC, _ = strconv.ParseFloat(fields[16], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HSS_EC_BCL, _ = strconv.ParseFloat(fields[17], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HSS_EC_BCU, _ = strconv.ParseFloat(fields[18], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.EC_VALUE, _ = strconv.ParseFloat(fields[19], 64)
-	}
-}
-
-func (s *STAT_NBRCTC) fill_STAT_NBRCTC(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen {
-		s.FY_OY, _ = strconv.ParseFloat(fields[1], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FY_ON, _ = strconv.ParseFloat(fields[2], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FN_OY, _ = strconv.ParseFloat(fields[3], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FN_ON, _ = strconv.ParseFloat(fields[4], 64)
-	}
-}
-
-func (s *STAT_DMAP) fill_STAT_DMAP(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen {
-		s.FY, _ = strconv.Atoi(fields[1])
-	}
-	i++
-	if i <= dataLen {
-		s.OY, _ = strconv.Atoi(fields[2])
-	}
-	i++
-	if i <= dataLen {
-		s.FBIAS, _ = strconv.ParseFloat(fields[3], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BADDELEY, _ = strconv.ParseFloat(fields[4], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.HAUSDORFF, _ = strconv.ParseFloat(fields[5], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.MED_FO, _ = strconv.ParseFloat(fields[6], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.MED_OF, _ = strconv.ParseFloat(fields[7], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.MED_MIN, _ = strconv.ParseFloat(fields[8], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.MED_MAX, _ = strconv.ParseFloat(fields[9], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.MED_MEAN, _ = strconv.ParseFloat(fields[10], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FOM_FO, _ = strconv.ParseFloat(fields[11], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FOM_OF, _ = strconv.ParseFloat(fields[12], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FOM_MIN, _ = strconv.ParseFloat(fields[13], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FOM_MAX, _ = strconv.ParseFloat(fields[14], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FOM_MEAN, _ = strconv.ParseFloat(fields[15], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ZHU_FO, _ = strconv.ParseFloat(fields[16], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ZHU_OF, _ = strconv.ParseFloat(fields[17], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ZHU_MIN, _ = strconv.ParseFloat(fields[18], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ZHU_MAX, _ = strconv.ParseFloat(fields[19], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ZHU_MEAN, _ = strconv.ParseFloat(fields[20], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.G, _ = strconv.ParseFloat(fields[21], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.GBETA, _ = strconv.ParseFloat(fields[22], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BETA_VALUE, _ = strconv.ParseFloat(fields[23], 64)
-	}
-}
-
-func (s *STAT_PRC) fill_STAT_PRC(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen { // the first field of the repeating fields is the TOTAL, the second field is the 1st dimenSion of the 1st sequence (there might be only one sequence)
-		var value interface{}
-		count, err := strconv.Atoi(fields[1])
-		if err != nil {
-			count = 0
-		}
-		keyPrefixes := []string{"THRESH_", "PODY_", "POFD_"}
-		s.THRESH = make(map[string]interface{})
-		for group := 1; group <= count; group++ {
-			for index := 2; index <= len(keyPrefixes); index++ {
-				key := fmt.Sprintf("%s_%d", keyPrefixes[index-1], index)
-				if index > len(fields) { // sometimes the data line is truncated - we will set expected data to "NA"
-					value = "NA"
-				} else {
-					value, err = strconv.ParseFloat(fields[index], 64)
-					if err != nil { // sometimes there can be these NA values in the data, which will be left out of json
-						value = "NA"
-					}
-				}
-				s.THRESH[key] = value
-			}
-		}
+		s.O_RATE_BCU, _ = strconv.ParseFloat(fields[18], 64)
 	}
 }
 
@@ -7832,559 +8385,6 @@ func (s *STAT_RELP) fill_STAT_RELP(fields []string) {
 				s.ENS[key] = value
 			}
 		}
-	}
-}
-
-func (s *STAT_VL1L2) fill_STAT_VL1L2(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen {
-		s.UFBAR, _ = strconv.ParseFloat(fields[1], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.VFBAR, _ = strconv.ParseFloat(fields[2], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.UOBAR, _ = strconv.ParseFloat(fields[3], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.VOBAR, _ = strconv.ParseFloat(fields[4], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.UVFOBAR, _ = strconv.ParseFloat(fields[5], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.UVFFBAR, _ = strconv.ParseFloat(fields[6], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.UVOOBAR, _ = strconv.ParseFloat(fields[7], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.F_SPEED_BAR, _ = strconv.ParseFloat(fields[8], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.O_SPEED_BAR, _ = strconv.ParseFloat(fields[9], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.TOTAL_DIR, _ = strconv.ParseFloat(fields[10], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.DIR_ME, _ = strconv.ParseFloat(fields[11], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.DIR_MAE, _ = strconv.ParseFloat(fields[12], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.DIR_MSE, _ = strconv.ParseFloat(fields[13], 64)
-	}
-}
-
-func (s *STAT_GENMPR) fill_STAT_GENMPR(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen {
-		s.INDEX, _ = strconv.Atoi(fields[1])
-	}
-	i++
-	if i <= dataLen {
-		s.STORM_ID = fields[2]
-	}
-	i++
-	if i <= dataLen {
-		s.PROB_LEAD, _ = strconv.ParseFloat(fields[3], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.PROB_VAL, _ = strconv.ParseFloat(fields[4], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AGEN_INIT = fields[5]
-	}
-	i++
-	if i <= dataLen {
-		s.AGEN_FHR = fields[6]
-	}
-	i++
-	if i <= dataLen {
-		s.AGEN_LAT, _ = strconv.ParseFloat(fields[7], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AGEN_LON, _ = strconv.ParseFloat(fields[8], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AGEN_DLAND, _ = strconv.ParseFloat(fields[9], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BGEN_LAT, _ = strconv.ParseFloat(fields[10], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BGEN_LON, _ = strconv.ParseFloat(fields[11], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BGEN_DLAND, _ = strconv.ParseFloat(fields[12], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.GEN_DIST, _ = strconv.ParseFloat(fields[13], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.GEN_TDIFF = fields[14]
-	}
-	i++
-	if i <= dataLen {
-		s.INIT_TDIFF = fields[15]
-	}
-	i++
-	if i <= dataLen {
-		s.DEV_CAT = fields[16]
-	}
-	i++
-	if i <= dataLen {
-		s.OPS_CAT = fields[17]
-	}
-}
-
-func (s *MODE_OBJ) fill_MODE_OBJ(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.OBJECT_ID = fields[0]
-	}
-	i++
-	if i <= dataLen {
-		s.OBJECT_CAT = fields[1]
-	}
-	i++
-	if i <= dataLen {
-		s.CENTROID_X, _ = strconv.ParseFloat(fields[2], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CENTROID_Y, _ = strconv.ParseFloat(fields[3], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CENTROID_LAT, _ = strconv.ParseFloat(fields[4], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CENTROID_LON, _ = strconv.ParseFloat(fields[5], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AXIS_ANG, _ = strconv.ParseFloat(fields[6], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.LENGTH, _ = strconv.ParseFloat(fields[7], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.WIDTH, _ = strconv.ParseFloat(fields[8], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AREA, _ = strconv.Atoi(fields[9])
-	}
-	i++
-	if i <= dataLen {
-		s.AREA_THRESH, _ = strconv.Atoi(fields[10])
-	}
-	i++
-	if i <= dataLen {
-		s.CURVATURE, _ = strconv.ParseFloat(fields[11], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CURVATURE_X, _ = strconv.ParseFloat(fields[12], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CURVATURE_Y, _ = strconv.ParseFloat(fields[13], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.COMPLEXITY, _ = strconv.ParseFloat(fields[14], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTENSITY_10, _ = strconv.ParseFloat(fields[15], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTENSITY_25, _ = strconv.ParseFloat(fields[16], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTENSITY_50, _ = strconv.ParseFloat(fields[17], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTENSITY_75, _ = strconv.ParseFloat(fields[18], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTENSITY_90, _ = strconv.ParseFloat(fields[19], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTENSITY_USER, _ = strconv.ParseFloat(fields[20], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTENSITY_SUM, _ = strconv.ParseFloat(fields[21], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CENTROID_DIST, _ = strconv.ParseFloat(fields[22], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.BOUNDARY_DIST, _ = strconv.ParseFloat(fields[23], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CONVEX_HULL_DIST, _ = strconv.ParseFloat(fields[24], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ANGLE_DIFF, _ = strconv.ParseFloat(fields[25], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ASPECT_DIFF, _ = strconv.ParseFloat(fields[26], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AREA_RATIO, _ = strconv.ParseFloat(fields[27], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTERSECTION_AREA, _ = strconv.ParseFloat(fields[28], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.UNION_AREA, _ = strconv.ParseFloat(fields[29], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SYMMETRIC_DIFF, _ = strconv.ParseFloat(fields[30], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTERSECTION_OVER_AREA, _ = strconv.ParseFloat(fields[31], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CURVATURE_RATIO, _ = strconv.ParseFloat(fields[32], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.COMPLEXITY_RATIO, _ = strconv.ParseFloat(fields[33], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.PERCENTILE_INTENSITY_RATIO, _ = strconv.ParseFloat(fields[34], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTEREST, _ = strconv.ParseFloat(fields[35], 64)
-	}
-}
-
-func (s *STAT_CTC) fill_STAT_CTC(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen {
-		s.FY_OY, _ = strconv.ParseFloat(fields[1], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FY_ON, _ = strconv.ParseFloat(fields[2], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FN_OY, _ = strconv.ParseFloat(fields[3], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.FN_ON, _ = strconv.ParseFloat(fields[4], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.EC_VALUE, _ = strconv.ParseFloat(fields[5], 64)
-	}
-}
-
-func (s *STAT_SEEPS) fill_STAT_SEEPS(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen {
-		s.ODFL, _ = strconv.ParseFloat(fields[1], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.ODFH, _ = strconv.ParseFloat(fields[2], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OLFD, _ = strconv.ParseFloat(fields[3], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OLFH, _ = strconv.ParseFloat(fields[4], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OHFD, _ = strconv.ParseFloat(fields[5], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.OHFL, _ = strconv.ParseFloat(fields[6], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.PF1, _ = strconv.ParseFloat(fields[7], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.PF2, _ = strconv.ParseFloat(fields[8], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.PF3, _ = strconv.ParseFloat(fields[9], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.PV1, _ = strconv.ParseFloat(fields[10], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.PV2, _ = strconv.ParseFloat(fields[11], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.PV3, _ = strconv.ParseFloat(fields[12], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.MEAN_FCST, _ = strconv.ParseFloat(fields[13], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.MEAN_OBS, _ = strconv.ParseFloat(fields[14], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.SEEPS, _ = strconv.ParseFloat(fields[15], 64)
-	}
-}
-
-func (s *STAT_PJC) fill_STAT_PJC(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen { // the first field of the repeating fields is the TOTAL, the second field is the 1st dimenSion of the 1st sequence (there might be only one sequence)
-		var value interface{}
-		count, err := strconv.Atoi(fields[1])
-		if err != nil {
-			count = 0
-		}
-		keyPrefixes := []string{"THRESH_", "OY_TP_", "ON_TP_", "CALIBRATION_", "REFINEMENT", "LIKELIHOOD_", "BASER_"}
-		s.THRESH = make(map[string]interface{})
-		for group := 1; group <= count; group++ {
-			for index := 2; index <= len(keyPrefixes); index++ {
-				key := fmt.Sprintf("%s_%d", keyPrefixes[index-1], index)
-				if index > len(fields) { // sometimes the data line is truncated - we will set expected data to "NA"
-					value = "NA"
-				} else {
-					value, err = strconv.ParseFloat(fields[index], 64)
-					if err != nil { // sometimes there can be these NA values in the data, which will be left out of json
-						value = "NA"
-					}
-				}
-				s.THRESH[key] = value
-			}
-		}
-	}
-}
-
-func (s *MTD_3DSINGLE) fill_MTD_3DSINGLE(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.OBJECT_ID = fields[0]
-	}
-	i++
-	if i <= dataLen {
-		s.OBJECT_CAT = fields[1]
-	}
-	i++
-	if i <= dataLen {
-		s.CENTROID_X, _ = strconv.ParseFloat(fields[2], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CENTROID_Y, _ = strconv.ParseFloat(fields[3], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CENTROID_T, _ = strconv.ParseFloat(fields[4], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CENTROID_LAT, _ = strconv.ParseFloat(fields[5], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.CENTROID_LON, _ = strconv.ParseFloat(fields[6], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.X_DOT, _ = strconv.ParseFloat(fields[7], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.Y_DOT, _ = strconv.ParseFloat(fields[8], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.AXIS_ANG, _ = strconv.ParseFloat(fields[9], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.VOLUME, _ = strconv.Atoi(fields[10])
-	}
-	i++
-	if i <= dataLen {
-		s.START_TIME, _ = strconv.Atoi(fields[11])
-	}
-	i++
-	if i <= dataLen {
-		s.END_TIME, _ = strconv.Atoi(fields[12])
-	}
-	i++
-	if i <= dataLen {
-		s.CDIST_TRAVELLED, _ = strconv.ParseFloat(fields[13], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTENSITY_10, _ = strconv.ParseFloat(fields[14], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTENSITY_25, _ = strconv.ParseFloat(fields[15], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTENSITY_50, _ = strconv.ParseFloat(fields[16], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTENSITY_75, _ = strconv.ParseFloat(fields[17], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTENSITY_90, _ = strconv.ParseFloat(fields[18], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.INTENSITY_USER, _ = strconv.ParseFloat(fields[19], 64)
-	}
-}
-
-func (s *TCST_TCDIAG) fill_TCST_TCDIAG(fields []string) {
-	dataLen := len(fields) - 1
-	i := -1
-	i++
-	if i <= dataLen {
-		s.TOTAL, _ = strconv.Atoi(fields[0])
-	}
-	i++
-	if i <= dataLen {
-		s.INDEX, _ = strconv.Atoi(fields[1])
-	}
-	i++
-	if i <= dataLen {
-		s.DIAG_SOURCE, _ = strconv.ParseFloat(fields[2], 64)
-	}
-	i++
-	if i <= dataLen {
-		s.TRACK_SOURCE = fields[3]
-	}
-	i++
-	if i <= dataLen {
-		s.FIELD_SOURCE = fields[4]
-	}
-	i++
-	if i <= dataLen { // the first field of the repeating fields is the TOTAL, the second field is the 1st dimenSion of the 1st sequence (there might be only one sequence)
-		var value interface{}
-		count, err := strconv.Atoi(fields[5])
-		if err != nil {
-			count = 0
-		}
-		keyPrefixes := []string{"DIAG_", "VALUE_"}
-		s.DIAG = make(map[string]interface{})
-		for group := 1; group <= count; group++ {
-			for index := 6; index <= len(keyPrefixes); index++ {
-				key := fmt.Sprintf("%s_%d", keyPrefixes[index-1], index)
-				if index > len(fields) { // sometimes the data line is truncated - we will set expected data to "NA"
-					value = "NA"
-				} else {
-					value = fields[index]
-				}
-				s.DIAG[key] = value
-			}
-		}
-	}
-	i++
-	if i <= dataLen {
-		s.INIT, _ = strconv.Atoi(fields[8])
 	}
 }
 


### PR DESCRIPTION
Sometimes there are fields in the header that contradict our document merging schema. For example cyclone data can have INIT, VALID, AND LEAD times in the header section of the first line in an output file. When this happens there now exists the ability to specify "disallow" fields in the buildHeaderUtilities.DataKeyMap. If these fields are date fields they also have to be converted to epochs.

This PR handles all that.